### PR TITLE
优化 Kiro prompt cache 稳定性

### DIFF
--- a/backend/internal/handler/admin/user_platform_quota_admin_test.go
+++ b/backend/internal/handler/admin/user_platform_quota_admin_test.go
@@ -112,9 +112,9 @@ func TestUpdateUserPlatformQuotas_Success(t *testing.T) {
 	if repo.upsertCalls[0].userID != 42 || len(repo.upsertCalls[0].records) != 2 {
 		t.Errorf("unexpected upsert call: %+v", repo.upsertCalls[0])
 	}
-	// 缓存失效：请求中 2 个 platform + 软删除的 2 个 platform（gemini, antigravity）= 4 次
-	if len(cache.deleteCalls) != 4 {
-		t.Errorf("expected 4 cache delete calls, got %d: %+v", len(cache.deleteCalls), cache.deleteCalls)
+	// 缓存失效：请求中 2 个 platform + 软删除的 3 个 platform（gemini, antigravity, kiro）= 5 次。
+	if len(cache.deleteCalls) != 5 {
+		t.Errorf("expected 5 cache delete calls, got %d: %+v", len(cache.deleteCalls), cache.deleteCalls)
 	}
 }
 

--- a/backend/internal/pkg/kiro/signature.go
+++ b/backend/internal/pkg/kiro/signature.go
@@ -33,7 +33,10 @@ func thinkingSignature(content, model, messageID string) string {
 	if elem, ok := signatureCacheMap[cacheKey]; ok {
 		signatureLRU.MoveToFront(elem)
 		signatureCacheMu.Unlock()
-		return elem.Value.(*sigCacheEntry).value
+		if entry, ok := elem.Value.(*sigCacheEntry); ok && entry != nil {
+			return entry.value
+		}
+		return ""
 	}
 	signatureCacheMu.Unlock()
 
@@ -42,8 +45,9 @@ func thinkingSignature(content, model, messageID string) string {
 	signatureCacheMu.Lock()
 	for signatureLRU.Len() >= signatureCacheMaxSize {
 		if oldest := signatureLRU.Back(); oldest != nil {
-			entry := oldest.Value.(*sigCacheEntry)
-			delete(signatureCacheMap, entry.key)
+			if entry, ok := oldest.Value.(*sigCacheEntry); ok && entry != nil {
+				delete(signatureCacheMap, entry.key)
+			}
 			signatureLRU.Remove(oldest)
 		}
 	}
@@ -63,17 +67,17 @@ func generateClaudeSignature(thinkingContent, model, messageID string) string {
 
 	keyMaterial := deriveSignatureKey(model, messageID)
 	mac := hmac.New(sha256.New, keyMaterial)
-	mac.Write([]byte(thinkingContent))
+	_, _ = mac.Write([]byte(thinkingContent))
 	hmacResult := mac.Sum(nil)
 
 	fillerKey := hmac.New(sha256.New, keyMaterial)
-	fillerKey.Write([]byte("payload"))
-	fillerKey.Write([]byte(thinkingContent))
+	_, _ = fillerKey.Write([]byte("payload"))
+	_, _ = fillerKey.Write([]byte(thinkingContent))
 	filler := fillerKey.Sum(nil)
 	for len(filler) < 110 {
 		next := hmac.New(sha256.New, keyMaterial)
-		next.Write(filler)
-		next.Write([]byte{byte(len(filler))})
+		_, _ = next.Write(filler)
+		_, _ = next.Write([]byte{byte(len(filler))})
 		filler = append(filler, next.Sum(nil)...)
 	}
 	filler = filler[:110]
@@ -95,9 +99,9 @@ func generateClaudeSignature(thinkingContent, model, messageID string) string {
 
 func deriveSignatureKey(model, messageID string) []byte {
 	mac := hmac.New(sha256.New, []byte("anthropic-thinking-signature-v2"))
-	mac.Write([]byte(model))
-	mac.Write([]byte(":"))
-	mac.Write([]byte(messageID))
+	_, _ = mac.Write([]byte(model))
+	_, _ = mac.Write([]byte(":"))
+	_, _ = mac.Write([]byte(messageID))
 	return mac.Sum(nil)
 }
 

--- a/backend/internal/pkg/kiro/translator.go
+++ b/backend/internal/pkg/kiro/translator.go
@@ -1335,8 +1335,10 @@ func renderKiroBuiltinIdentityPrompt(identity string) string {
 
 func buildInjectedSystemPrompt(systemPrompt string, thinking *thinkingDirective, toolChoiceHint string) string {
 	systemPrompt = strings.TrimSpace(systemPrompt)
-	timestampContext := fmt.Sprintf("[Context: Current time is %s]", time.Now().Format("2006-01-02 15:04:05 MST"))
-	promptParts := []string{renderKiroBuiltinIdentityPrompt(""), timestampContext}
+	promptParts := []string{renderKiroBuiltinIdentityPrompt("")}
+	if temporalContext := buildKiroTemporalContext(); temporalContext != "" {
+		promptParts = append(promptParts, temporalContext)
+	}
 	if systemPrompt != "" {
 		promptParts = append(promptParts, systemPrompt)
 	}
@@ -1369,6 +1371,17 @@ func buildInjectedSystemPrompt(systemPrompt string, thinking *thinkingDirective,
 		}
 	}
 	return systemPrompt
+}
+
+func buildKiroTemporalContext() string {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("SUB2API_KIRO_TIME_CONTEXT"))) {
+	case "date", "day":
+		return fmt.Sprintf("[Context: Current date is %s]", time.Now().Format("2006-01-02 MST"))
+	case "precise", "time", "full":
+		return fmt.Sprintf("[Context: Current time is %s]", time.Now().Format("2006-01-02 15:04:05 MST"))
+	default:
+		return ""
+	}
 }
 
 // buildAdditionalModelRequestFields 构建 Kiro payload 的 additionalModelRequestFields。
@@ -1444,24 +1457,6 @@ func budgetToEffort(budgetTokens int) string {
 	default:
 		return "xhigh"
 	}
-}
-
-func shouldUseFastEmptySystemPrompt(claudeBody []byte, baseSystem string, thinking *thinkingDirective, toolChoiceHint string) bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv("SUB2API_KIRO_FAST_EMPTY_SYSTEM"))) {
-	case "1", "true", "yes", "on":
-	default:
-		return false
-	}
-	if strings.TrimSpace(baseSystem) != "" || thinking != nil || strings.TrimSpace(toolChoiceHint) != "" {
-		return false
-	}
-	if !isToolChoiceNone(claudeBody) {
-		tools := gjson.GetBytes(claudeBody, "tools")
-		if tools.IsArray() && len(tools.Array()) > 0 {
-			return false
-		}
-	}
-	return true
 }
 
 func extractClaudeToolChoiceHint(claudeBody []byte, requestCtx *KiroRequestContext) string {

--- a/backend/internal/pkg/kiro/translator_test.go
+++ b/backend/internal/pkg/kiro/translator_test.go
@@ -55,11 +55,49 @@ func TestBuildKiroPayloadBasic(t *testing.T) {
 	require.Contains(t, systemContent, "<CRITICAL_OVERRIDE>")
 	require.Contains(t, systemContent, "You must never say that you are Kiro")
 	require.Contains(t, systemContent, "<identity>")
-	require.Contains(t, systemContent, "[Context: Current time is ")
 	require.Contains(t, systemContent, "You are a test system prompt.")
-	require.Less(t, strings.Index(systemContent, "<CRITICAL_OVERRIDE>"), strings.Index(systemContent, "[Context: Current time is "))
-	require.Less(t, strings.Index(systemContent, "[Context: Current time is "), strings.Index(systemContent, "You are a test system prompt."))
+	require.NotContains(t, systemContent, "[Context: Current date is ")
+	require.NotContains(t, systemContent, "[Context: Current time is ")
+	require.Less(t, strings.Index(systemContent, "<CRITICAL_OVERRIDE>"), strings.Index(systemContent, "You are a test system prompt."))
 	require.Equal(t, "I will follow these instructions.", gjson.GetBytes(payload, "conversationState.history.1.assistantResponseMessage.content").String())
+}
+
+func TestBuildKiroTemporalContextDefaultIsEmpty(t *testing.T) {
+	t.Setenv("SUB2API_KIRO_TIME_CONTEXT", "")
+
+	require.Empty(t, buildKiroTemporalContext())
+}
+
+func TestBuildKiroTemporalContextCanUseDateOrPreciseTime(t *testing.T) {
+	t.Setenv("SUB2API_KIRO_TIME_CONTEXT", "date")
+	require.Contains(t, buildKiroTemporalContext(), "[Context: Current date is ")
+
+	t.Setenv("SUB2API_KIRO_TIME_CONTEXT", "none")
+	require.Empty(t, buildKiroTemporalContext())
+
+	t.Setenv("SUB2API_KIRO_TIME_CONTEXT", "precise")
+	require.Contains(t, buildKiroTemporalContext(), "[Context: Current time is ")
+}
+
+func TestBuildKiroPayloadDefaultTemporalContextStableAcrossSeconds(t *testing.T) {
+	t.Setenv("SUB2API_KIRO_TIME_CONTEXT", "")
+	body := []byte(`{
+		"model":"claude-sonnet-4-5",
+		"system":"stable sys",
+		"messages":[{"role":"user","content":"hello"}]
+	}`)
+
+	first, err := BuildKiroPayloadWithContext(body, "claude-sonnet-4.5", "", "AI_EDITOR", nil)
+	require.NoError(t, err)
+	time.Sleep(1100 * time.Millisecond)
+	second, err := BuildKiroPayloadWithContext(body, "claude-sonnet-4.5", "", "AI_EDITOR", nil)
+	require.NoError(t, err)
+
+	require.NotEqual(t,
+		gjson.GetBytes(first.Payload, "conversationState.conversationId").String(),
+		gjson.GetBytes(second.Payload, "conversationState.conversationId").String(),
+	)
+	require.Equal(t, stripKiroConversationIDForTest(t, first.Payload), stripKiroConversationIDForTest(t, second.Payload))
 }
 
 func TestBuildKiroPayloadAlwaysIgnoresClientConversationMetadata(t *testing.T) {
@@ -74,6 +112,18 @@ func TestBuildKiroPayloadAlwaysIgnoresClientConversationMetadata(t *testing.T) {
 	require.NotEmpty(t, conversationID)
 	require.NotEqual(t, "client-conv", conversationID)
 	require.False(t, gjson.GetBytes(result.Payload, "conversationState.agentContinuationId").Exists())
+}
+
+func stripKiroConversationIDForTest(t *testing.T, payloadBytes []byte) []byte {
+	t.Helper()
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
+	state, ok := payload["conversationState"].(map[string]any)
+	require.True(t, ok)
+	delete(state, "conversationId")
+	out, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return out
 }
 
 func TestBuildKiroPayloadDoesNotInsertUserDotBeforeLeadingAssistant(t *testing.T) {
@@ -278,7 +328,7 @@ func TestBuildKiroPayloadInjectsThinkingIntoHistory(t *testing.T) {
 	require.Equal(t, "hello kiro", gjson.GetBytes(payload, "conversationState.currentMessage.userInputMessage.content").String())
 	systemContent := gjson.GetBytes(payload, "conversationState.history.0.userInputMessage.content").String()
 	require.Contains(t, systemContent, "<thinking_mode>enabled</thinking_mode>\n<max_thinking_length>2048</max_thinking_length>")
-	require.Contains(t, systemContent, "[Context: Current time is ")
+	require.NotContains(t, systemContent, "[Context: Current time is ")
 	require.Equal(t, "I will follow these instructions.", gjson.GetBytes(payload, "conversationState.history.1.assistantResponseMessage.content").String())
 }
 
@@ -294,7 +344,7 @@ func TestBuildKiroPayloadInjectsAdaptiveThinkingForOpus46ThinkingModel(t *testin
 
 	systemContent := gjson.GetBytes(payload, "conversationState.history.0.userInputMessage.content").String()
 	require.Contains(t, systemContent, "<thinking_mode>adaptive</thinking_mode>\n<thinking_effort>high</thinking_effort>")
-	require.Contains(t, systemContent, "[Context: Current time is ")
+	require.NotContains(t, systemContent, "[Context: Current time is ")
 }
 
 func TestBuildKiroPayloadAddsAdditionalModelRequestFieldsForOutputConfigModels(t *testing.T) {

--- a/backend/internal/service/account_test_service_kiro_test.go
+++ b/backend/internal/service/account_test_service_kiro_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestAccountTestService_KiroUsesKiroUpstreamInsteadOfAnthropic(t *testing.T) {
@@ -261,7 +262,7 @@ func TestBuildKiroPayloadForAccount_KiroBuilderIDWithoutProfileArnOmitsProfileAr
 	payloadBytes, err := json.Marshal(testPayload)
 	require.NoError(t, err)
 
-	buildResult, err := (&GatewayService{}).buildKiroPayloadForAccount(context.Background(), account, payloadBytes, "claude-sonnet-4-6", "kiro-access-token", "claude-sonnet-4-6", nil)
+	buildResult, err := (&GatewayService{}).buildKiroPayloadForAccount(context.Background(), account, nil, payloadBytes, "claude-sonnet-4-6", "kiro-access-token", "claude-sonnet-4-6", nil)
 	require.NoError(t, err)
 	kiroPayload := buildResult.Payload
 	require.NotContains(t, string(kiroPayload), `"profileArn":`)
@@ -287,7 +288,7 @@ func TestBuildKiroPayloadForAccount_KiroBuilderIDUsesCredentialProfileArn(t *tes
 	payloadBytes, err := json.Marshal(testPayload)
 	require.NoError(t, err)
 
-	buildResult, err := (&GatewayService{}).buildKiroPayloadForAccount(context.Background(), account, payloadBytes, "claude-sonnet-4-6", "kiro-access-token", "claude-sonnet-4-6", nil)
+	buildResult, err := (&GatewayService{}).buildKiroPayloadForAccount(context.Background(), account, nil, payloadBytes, "claude-sonnet-4-6", "kiro-access-token", "claude-sonnet-4-6", nil)
 	require.NoError(t, err)
 	kiroPayload := buildResult.Payload
 	require.Contains(t, string(kiroPayload), `"profileArn":"arn:aws:codewhisperer:us-east-1:123456789012:profile/CACHED"`)
@@ -313,8 +314,43 @@ func TestBuildKiroPayloadForAccount_KiroEnterpriseIDCOmitsMissingProfileArn(t *t
 	payloadBytes, err := json.Marshal(testPayload)
 	require.NoError(t, err)
 
-	buildResult, err := (&GatewayService{}).buildKiroPayloadForAccount(context.Background(), account, payloadBytes, "claude-sonnet-4-6", "kiro-access-token", "claude-sonnet-4-6", nil)
+	buildResult, err := (&GatewayService{}).buildKiroPayloadForAccount(context.Background(), account, nil, payloadBytes, "claude-sonnet-4-6", "kiro-access-token", "claude-sonnet-4-6", nil)
 	require.NoError(t, err)
 	kiroPayload := buildResult.Payload
 	require.NotContains(t, string(kiroPayload), `"profileArn":`)
+}
+
+func TestBuildKiroPayloadForAccount_StableConversationIDByDefault(t *testing.T) {
+	t.Setenv("SUB2API_KIRO_CONVERSATION_ID_MODE", "")
+	account := &Account{
+		ID:       44,
+		Name:     "kiro-stable-conversation",
+		Platform: PlatformKiro,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"refresh_token": "stable-refresh",
+			"profile_arn":   "arn:aws:codewhisperer:us-east-1:123456789012:profile/STABLE",
+		},
+	}
+	body := []byte(`{"model":"claude-sonnet-4-5","system":"stable sys","messages":[{"role":"user","content":"hello"}]}`)
+	ref := NewRequestBodyRef(body)
+	parsed, err := ParseGatewayRequest(ref, "anthropic")
+	require.NoError(t, err)
+	parsed.Group = &Group{Platform: PlatformKiro}
+	parsed.SessionContext = &SessionContext{APIKeyID: 9}
+
+	first, err := (&GatewayService{}).buildKiroPayloadForAccount(context.Background(), account, parsed, body, "claude-sonnet-4.5", "kiro-access-token", "claude-sonnet-4.5", nil)
+	require.NoError(t, err)
+	second, err := (&GatewayService{}).buildKiroPayloadForAccount(context.Background(), account, parsed, body, "claude-sonnet-4.5", "rotated-token", "claude-sonnet-4.5", nil)
+	require.NoError(t, err)
+
+	firstID := gjson.GetBytes(first.Payload, "conversationState.conversationId").String()
+	secondID := gjson.GetBytes(second.Payload, "conversationState.conversationId").String()
+	require.NotEmpty(t, firstID)
+	require.Equal(t, firstID, secondID)
+
+	t.Setenv("SUB2API_KIRO_CONVERSATION_ID_MODE", "random")
+	randomized, err := (&GatewayService{}).buildKiroPayloadForAccount(context.Background(), account, parsed, body, "claude-sonnet-4.5", "kiro-access-token", "claude-sonnet-4.5", nil)
+	require.NoError(t, err)
+	require.NotEqual(t, firstID, gjson.GetBytes(randomized.Payload, "conversationState.conversationId").String())
 }

--- a/backend/internal/service/kiro_http_helpers_test.go
+++ b/backend/internal/service/kiro_http_helpers_test.go
@@ -135,6 +135,7 @@ func TestBuildKiroPayloadForAccountPropagatesThinkingHeaders(t *testing.T) {
 	buildResult, err := (&GatewayService{}).buildKiroPayloadForAccount(
 		context.Background(),
 		account,
+		nil,
 		body,
 		"claude-sonnet-4.6",
 		"kiro-access-token",
@@ -161,6 +162,7 @@ func TestBuildKiroPayloadForAccountPreservesThinkingAliasAfterMapping(t *testing
 	buildResult, err := (&GatewayService{}).buildKiroPayloadForAccount(
 		context.Background(),
 		account,
+		nil,
 		body,
 		"claude-opus-4.6",
 		"kiro-access-token",
@@ -199,6 +201,7 @@ func TestBuildKiroPayloadForAccountMapsOpus47ToDottedModelID(t *testing.T) {
 	buildResult, err := (&GatewayService{}).buildKiroPayloadForAccount(
 		context.Background(),
 		account,
+		nil,
 		body,
 		modelID,
 		"kiro-access-token",
@@ -225,6 +228,7 @@ func TestBuildKiroPayloadForAccountDoesNotEnableThinkingForNonThinkingAlias(t *t
 	buildResult, err := (&GatewayService{}).buildKiroPayloadForAccount(
 		context.Background(),
 		account,
+		nil,
 		body,
 		"claude-opus-4.6",
 		"kiro-access-token",

--- a/backend/internal/service/kiro_runtime.go
+++ b/backend/internal/service/kiro_runtime.go
@@ -9,13 +9,17 @@ import (
 	"io"
 	mathrand "math/rand"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	kiropkg "github.com/Wei-Shaw/sub2api/internal/pkg/kiro"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/cespare/xxhash/v2"
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 	"go.uber.org/zap"
 )
 
@@ -353,7 +357,7 @@ func (s *GatewayService) executeKiroUpstreamWithParsed(ctx context.Context, acco
 
 	modelID := kiropkg.MapModel(mappedModel)
 	currentToken := token
-	buildResult, err := s.buildKiroPayloadForAccount(ctx, account, anthropicBody, modelID, currentToken, requestModel, headers)
+	buildResult, err := s.buildKiroPayloadForAccount(ctx, account, parsed, anthropicBody, modelID, currentToken, requestModel, headers)
 	if err != nil {
 		return nil, requestCtx, err
 	}
@@ -457,7 +461,7 @@ func (s *GatewayService) executeKiroUpstreamWithParsed(ctx context.Context, acco
 					if refreshErr == nil && strings.TrimSpace(refreshedToken) != "" {
 						currentToken = refreshedToken
 						accountKey = buildKiroAccountKey(account)
-						buildResult, err = s.buildKiroPayloadForAccount(ctx, account, anthropicBody, modelID, currentToken, requestModel, headers)
+						buildResult, err = s.buildKiroPayloadForAccount(ctx, account, parsed, anthropicBody, modelID, currentToken, requestModel, headers)
 						if err != nil {
 							return nil, requestCtx, err
 						}
@@ -517,25 +521,120 @@ func buildKiroEndpoints(account *Account) []kiroEndpointConfig {
 	}
 }
 
-func (s *GatewayService) buildKiroPayloadForAccount(ctx context.Context, account *Account, anthropicBody []byte, modelID, token, requestModel string, headers http.Header) (*kiropkg.KiroBuildResult, error) {
+func (s *GatewayService) buildKiroPayloadForAccount(ctx context.Context, account *Account, parsed *ParsedRequest, anthropicBody []byte, modelID, token, requestModel string, headers http.Header) (*kiropkg.KiroBuildResult, error) {
 	_ = s
 	_ = ctx
 	_ = token
 	profileArn := resolveKiroPayloadProfileArn(account)
 	anthropicBody = prepareKiroPayloadBodyForRequestModel(anthropicBody, requestModel)
-	return kiropkg.BuildKiroPayloadWithContext(anthropicBody, modelID, profileArn, "AI_EDITOR", headers)
+	buildResult, err := kiropkg.BuildKiroPayloadWithContext(anthropicBody, modelID, profileArn, "AI_EDITOR", headers)
+	if err != nil {
+		return nil, err
+	}
+	if stableID := stableKiroConversationID(account, parsed, anthropicBody, modelID, profileArn); stableID != "" {
+		if next, setErr := sjson.SetBytes(buildResult.Payload, "conversationState.conversationId", stableID); setErr == nil {
+			buildResult.Payload = next
+		}
+	}
+	return buildResult, nil
+}
+
+func stableKiroConversationID(account *Account, parsed *ParsedRequest, anthropicBody []byte, modelID, profileArn string) string {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("SUB2API_KIRO_CONVERSATION_ID_MODE"))) {
+	case "random", "uuid", "off", "false", "0":
+		return ""
+	}
+	seed := stableKiroConversationSeed(account, parsed, anthropicBody, modelID, profileArn)
+	if seed == "" {
+		return ""
+	}
+	return generateSessionUUID(seed)
+}
+
+func stableKiroConversationSeed(account *Account, parsed *ParsedRequest, anthropicBody []byte, modelID, profileArn string) string {
+	var anchorType, anchor string
+	if parsed != nil {
+		if explicitID := strings.TrimSpace(parsed.ExplicitSessionID); explicitID != "" {
+			anchorType, anchor = "explicit", explicitID
+		} else if metadataUserID := strings.TrimSpace(parsed.MetadataUserID); metadataUserID != "" {
+			anchorType, anchor = "metadata", metadataUserID
+		} else if systemText := extractTextFromSystemRaw(parsed.SystemRaw()); systemText != "" {
+			anchorType, anchor = "system", systemText
+		}
+	}
+	if anchor == "" && len(anthropicBody) > 0 {
+		if systemText := extractTextFromSystemRaw([]byte(gjson.GetBytes(anthropicBody, "system").Raw)); systemText != "" {
+			anchorType, anchor = "system", systemText
+		} else if firstUserText := extractFirstUserText(anthropicBody); firstUserText != "" {
+			anchorType, anchor = "first_user", firstUserText
+		}
+	}
+	if anchor == "" {
+		return ""
+	}
+
+	var sb strings.Builder
+	_, _ = sb.WriteString("kiro-conversation-v1|")
+	if account != nil {
+		_, _ = sb.WriteString("account:")
+		_, _ = sb.WriteString(strconv.FormatInt(account.ID, 10))
+		_, _ = sb.WriteString("|credential:")
+		_, _ = sb.WriteString(kiroCacheCredentialIdentity(account))
+		_, _ = sb.WriteString("|")
+	}
+	if parsed != nil && parsed.SessionContext != nil {
+		_, _ = sb.WriteString("api_key:")
+		_, _ = sb.WriteString(strconv.FormatInt(parsed.SessionContext.APIKeyID, 10))
+		_, _ = sb.WriteString("|")
+	}
+	_, _ = sb.WriteString("model:")
+	_, _ = sb.WriteString(strings.TrimSpace(modelID))
+	_, _ = sb.WriteString("|profile:")
+	_, _ = sb.WriteString(strings.TrimSpace(profileArn))
+	_, _ = sb.WriteString("|anchor:")
+	_, _ = sb.WriteString(anchorType)
+	_, _ = sb.WriteString(":")
+	_, _ = sb.WriteString(anchor)
+	return sb.String()
 }
 
 func logKiroStatelessReplay(account *Account, payload []byte) {
 	if account == nil {
 		return
 	}
+	conversationID := gjson.GetBytes(payload, "conversationState.conversationId").String()
+	systemPrompt := gjson.GetBytes(payload, "conversationState.history.0.userInputMessage.content").String()
+	currentContent := gjson.GetBytes(payload, "conversationState.currentMessage.userInputMessage.content").String()
 	logger.L().Info("kiro.stateless_replay",
 		zap.Int64("selected_account_id", account.ID),
 		zap.Bool("stateless_replay", true),
 		zap.Int("history_count", len(gjson.GetBytes(payload, "conversationState.history").Array())),
 		zap.Bool("has_agent_continuation_id", gjson.GetBytes(payload, "conversationState.agentContinuationId").Exists()),
+		zap.String("conversation_id_hash", hashKiroLogString(conversationID)),
+		zap.String("payload_hash_no_conversation_id", hashKiroPayloadWithoutConversationID(payload)),
+		zap.String("system_prompt_hash", hashKiroLogString(systemPrompt)),
+		zap.Int("system_prompt_len", len(systemPrompt)),
+		zap.String("current_content_hash", hashKiroLogString(currentContent)),
+		zap.Int("tool_count", len(gjson.GetBytes(payload, "conversationState.currentMessage.userInputMessage.userInputMessageContext.tools").Array())),
 	)
+}
+
+func hashKiroPayloadWithoutConversationID(payload []byte) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	normalized := payload
+	if next, err := sjson.DeleteBytes(payload, "conversationState.conversationId"); err == nil {
+		normalized = next
+	}
+	return strconv.FormatUint(xxhash.Sum64(normalized), 36)
+}
+
+func hashKiroLogString(value string) string {
+	if value == "" {
+		return ""
+	}
+	return strconv.FormatUint(xxhash.Sum64String(value), 36)
 }
 
 func prepareKiroPayloadBodyForRequestModel(anthropicBody []byte, requestModel string) []byte {

--- a/backend/internal/service/kiro_session_test.go
+++ b/backend/internal/service/kiro_session_test.go
@@ -10,21 +10,21 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func TestBuildKiroPayloadForAccountUsesStatelessConversationIDs(t *testing.T) {
+func TestBuildKiroPayloadForAccountUsesStableConversationIDs(t *testing.T) {
 	svc := &GatewayService{}
 	account := &Account{ID: 40, Credentials: map[string]any{"profile_arn": "profile-a"}}
 	body := []byte(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hello","additional_kwargs":{"conversationId":"client-conv","continuationId":"client-cont"}}]}`)
 
-	first, err := svc.buildKiroPayloadForAccount(context.Background(), account, body, "claude-sonnet-4.5", "token", "claude-sonnet-4-5", nil)
+	first, err := svc.buildKiroPayloadForAccount(context.Background(), account, nil, body, "claude-sonnet-4.5", "token", "claude-sonnet-4-5", nil)
 	require.NoError(t, err)
-	second, err := svc.buildKiroPayloadForAccount(context.Background(), account, body, "claude-sonnet-4.5", "token", "claude-sonnet-4-5", nil)
+	second, err := svc.buildKiroPayloadForAccount(context.Background(), account, nil, body, "claude-sonnet-4.5", "token", "claude-sonnet-4-5", nil)
 	require.NoError(t, err)
 
 	firstConversationID := gjson.GetBytes(first.Payload, "conversationState.conversationId").String()
 	secondConversationID := gjson.GetBytes(second.Payload, "conversationState.conversationId").String()
 	require.NotEmpty(t, firstConversationID)
 	require.NotEmpty(t, secondConversationID)
-	require.NotEqual(t, firstConversationID, secondConversationID)
+	require.Equal(t, firstConversationID, secondConversationID)
 	require.NotEqual(t, "client-conv", firstConversationID)
 	require.False(t, gjson.GetBytes(first.Payload, "conversationState.agentContinuationId").Exists())
 	require.False(t, gjson.GetBytes(second.Payload, "conversationState.agentContinuationId").Exists())
@@ -43,7 +43,7 @@ func TestBuildKiroPayloadForAccountReplaysFullMessagesIntoHistory(t *testing.T) 
 		]
 	}`)
 
-	result, err := svc.buildKiroPayloadForAccount(context.Background(), account, body, "claude-sonnet-4.5", "token", "claude-sonnet-4-5", nil)
+	result, err := svc.buildKiroPayloadForAccount(context.Background(), account, nil, body, "claude-sonnet-4.5", "token", "claude-sonnet-4-5", nil)
 	require.NoError(t, err)
 
 	history := gjson.GetBytes(result.Payload, "conversationState.history").Array()

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -99,6 +99,16 @@ SERVER_H2C_MAX_UPLOAD_BUFFER_PER_STREAM=524288
 # standard: 完整 SaaS 功能，包含计费/余额校验；simple: 隐藏 SaaS 功能并跳过计费/余额校验
 RUN_MODE=standard
 
+# Kiro prompt cache optimization.
+# Empty disables injected time/date context for the most stable cache prefix.
+# Optional values: date, precise. Use precise only if exact current time is more important than cache hit rate.
+SUB2API_KIRO_TIME_CONTEXT=
+
+# Kiro conversationId strategy.
+# stable (default) derives a deterministic UUID from account/session anchors for better upstream cache reuse.
+# Set to random to restore per-request random conversationId behavior.
+SUB2API_KIRO_CONVERSATION_ID_MODE=stable
+
 # Timezone
 TZ=Asia/Shanghai
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -216,12 +216,30 @@ docker compose down -v
 | `ADMIN_EMAIL` | No | `admin@sub2api.local` | Admin email |
 | `ADMIN_PASSWORD` | No | *(auto-generated)* | Admin password |
 | `TZ` | No | `Asia/Shanghai` | Timezone |
+| `SUB2API_KIRO_TIME_CONTEXT` | No | *(empty)* | Kiro prompt cache knob. Empty means no injected date/time context. Set to `date` or `precise` only when current date/time in every request is more important than cache reuse. |
+| `SUB2API_KIRO_CONVERSATION_ID_MODE` | No | `stable` | Kiro prompt cache knob. `stable` derives a deterministic upstream conversation ID from account/session anchors. Set to `random` to restore per-request random IDs. |
 | `GEMINI_OAUTH_CLIENT_ID` | No | *(builtin)* | Google OAuth client ID (Gemini OAuth). Leave empty to use the built-in Gemini CLI client. |
 | `GEMINI_OAUTH_CLIENT_SECRET` | No | *(builtin)* | Google OAuth client secret (Gemini OAuth). Leave empty to use the built-in Gemini CLI client. |
 | `GEMINI_OAUTH_SCOPES` | No | *(default)* | OAuth scopes (Gemini OAuth) |
 | `GEMINI_QUOTA_POLICY` | No | *(empty)* | JSON overrides for Gemini local quota simulation (Code Assist only). |
 
 See `.env.example` for all available options.
+
+#### Kiro Prompt Cache Knobs
+
+These settings are deployment/runtime options, not end-user features. For Docker Compose deployments, set them in `.env` and restart the service.
+
+```bash
+# Default cache-friendly behavior:
+SUB2API_KIRO_TIME_CONTEXT=
+SUB2API_KIRO_CONVERSATION_ID_MODE=stable
+
+# Compatibility rollback examples:
+SUB2API_KIRO_TIME_CONTEXT=date
+SUB2API_KIRO_CONVERSATION_ID_MODE=random
+```
+
+Keep `SUB2API_KIRO_TIME_CONTEXT` empty unless callers depend on the gateway injecting the current date/time into every Kiro request. Injecting precise time changes the prompt prefix every second and can prevent upstream prompt-cache reuse.
 
 > **Note:** The `docker-deploy.sh` script automatically generates `JWT_SECRET`, `TOTP_ENCRYPTION_KEY`, and `POSTGRES_PASSWORD` for you.
 

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -52,6 +52,8 @@ services:
       - SERVER_PORT=8080
       - SERVER_MODE=${SERVER_MODE:-release}
       - RUN_MODE=${RUN_MODE:-standard}
+      - SUB2API_KIRO_TIME_CONTEXT=${SUB2API_KIRO_TIME_CONTEXT:-}
+      - SUB2API_KIRO_CONVERSATION_ID_MODE=${SUB2API_KIRO_CONVERSATION_ID_MODE:-stable}
 
       # =======================================================================
       # Database Configuration (PostgreSQL)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -48,6 +48,8 @@ services:
       - SERVER_PORT=8080
       - SERVER_MODE=${SERVER_MODE:-release}
       - RUN_MODE=${RUN_MODE:-standard}
+      - SUB2API_KIRO_TIME_CONTEXT=${SUB2API_KIRO_TIME_CONTEXT:-}
+      - SUB2API_KIRO_CONVERSATION_ID_MODE=${SUB2API_KIRO_CONVERSATION_ID_MODE:-stable}
 
       # =======================================================================
       # Database Configuration (PostgreSQL)


### PR DESCRIPTION
## 背景

这次主要处理 Kiro 请求在粘性会话和上游 prompt cache 复用上的稳定性问题。之前排查发现，部分字段会在每次请求变化，例如默认注入的当前时间、随机 `conversationId`，这些都会降低上游缓存命中的概率；同时需要补充日志，方便区分是账号漂移、payload 漂移，还是上游缓存本身没有命中。

## 这次改了什么

1. 默认不再向 Kiro system prompt 注入当前时间
   - 以前默认会注入类似 `Current time is ...` 的上下文，精确到秒会导致 prompt 前缀持续变化。
   - 现在默认不注入时间，最大化 prompt cache 前缀稳定性。
   - 如确实需要兼容旧行为，可通过 `SUB2API_KIRO_TIME_CONTEXT=date` 或 `precise` 打开。

2. Kiro 上游 `conversationId` 默认改为稳定生成
   - 以前每次请求都会生成随机 UUID。
   - 现在默认基于账号、凭据身份、API key、模型、profile、显式 session / metadata / system / 首条 user 等锚点生成稳定 UUID。
   - 如需回滚旧行为，可设置 `SUB2API_KIRO_CONVERSATION_ID_MODE=random`。

3. 补充 Kiro stateless replay 诊断日志
   - 新增 `conversation_id_hash`、`payload_hash_no_conversation_id`、`system_prompt_hash`、`current_content_hash`、`tool_count` 等字段。
   - 用于线上排查缓存未命中时，到底是会话 ID 变化、prompt 变化，还是请求内容本身变化。

4. 补充部署配置和说明
   - 在 Docker Compose 中透传两个运行时开关。
   - 在 `.env.example` 和 `deploy/README.md` 中说明默认值、用途和回滚方式。
   - 这两个开关是部署/运维参数，不是终端用户需要改代码的功能入口。

5. 清理 CI 阻塞项
   - 移除 cherry-pick 到干净分支后未使用的 fast-empty helper。
   - 对 `signature.go` 中 HMAC `Write` 和 LRU 类型断言做显式处理，避免 `golangci-lint` 阻塞 PR。
   - Kiro 平台加入后，管理员用户平台额度测试的缓存清理期望从 4 个平台更新为 5 个平台。

## 真实扣分测试补充

另有一轮脱敏的 Kiro raw event stream 测试使用上游 `meteringEvent.usage` / `unit=credit` 作为扣分依据，结论如下：

- 稳定上下文直接拼进 `currentMessage`：没有稳定降扣分，后续请求基本仍是冷请求档位。
- 稳定上下文放进 `conversationState.history` 的固定 user/assistant pair：后续请求稳定降到热缓存档位，实测节省约 `43%`。
- 模拟真实多轮对话增长：稳定 history 仍能命中，新增轮次只带来小幅递增扣分，实测节省约 `42%`。
- 在稳定 history 前面加入动态 `request_id` / 时间戳：基本毁掉缓存，扣分回到冷请求档位。
- 只复用 `conversationId`、后续不重发 history：扣分更低，但模型拿不到原上下文，不能作为可用策略。
- 同一稳定 history 换账号后，目标账号第一次仍是冷请求、第二次才热，因此同一 cache key/session 仍应 sticky 到同一个 Kiro 账号。

这组结果支持本 PR 的方向：稳定 prompt 前缀、默认去掉时间注入、尽量保持同一会话落到同一 Kiro 账号。也说明线上验证不能只看本地 `usage_logs.actual_cost` 或推导 token 数，应该优先看 Kiro raw metering credits。

## 没有放进这次 PR 的内容

这次没有实现“第二条 user 出现后从弱锚点迁移到强锚点”的进一步兜底逻辑。当前策略仍然建议客户端/智能体优先传显式会话 ID，例如 `X-Session-ID` 或 `Anthropic-Session-Id`。如果没有显式会话 ID，服务端只能基于已有请求内容做兜底，无法在第一轮完全相同的多个会话之间做到绝对区分。

这次也没有把“任意客户端单条 user 里混合的固定项目上下文”自动拆成 Kiro history。实测显示，大段稳定上下文如果一直拼在 `currentMessage` 内，缓存效果不稳定；但服务端很难可靠地区分哪些文本是智能体固定提示、哪些是用户本轮真实问题。更安全的方式是客户端/智能体把固定上下文作为 system 或历史消息传入，让转换后的 Kiro payload 形成 byte-stable history。

## 验证

已在本地基于最新 `midstream/main` 的干净 PR 分支验证：

```bash
go test ./internal/pkg/kiro
go test -tags=unit ./internal/service -run Kiro|StableConversation|StickySession
go test ./internal/service -run Kiro|Antigravity|ModelRouting|TokenCacheKey|GatewayService
go test -tags=unit ./internal/handler/admin -run TestUpdateUserPlatformQuotas_Success
git diff --check
```

## 线上验证建议

合入并部署后，用同一账号、同一模型、同一 byte-stable history 连续请求，重点观察：

- `sticky.hash_source` 是否稳定，不应退化到完整 messages 导致逐轮变化。
- `kiro.stateless_replay.conversation_id_hash` 是否稳定。
- `system_prompt_hash` 是否不再随时间变化。
- `payload_hash_no_conversation_id` 是否只在真实新增对话轮次时变化。
- 上游 Kiro raw `meteringEvent.usage` / credits 是否在 warm-up 后下降到热缓存档位。