### PR TITLE
fix(kiro): stop double-counting cache_read tokens in input_tokens

### DIFF
--- a/backend/internal/pkg/kiro/translator.go
+++ b/backend/internal/pkg/kiro/translator.go
@@ -4052,11 +4052,6 @@ func updateUsageFromEvent(usage *Usage, eventType string, event map[string]any) 
 		}
 		if value, ok := toInt(tokenUsage["cacheReadInputTokens"]); ok {
 			usage.CacheReadInputTokens = value
-			if usage.InputTokens == 0 {
-				usage.InputTokens = value
-			} else {
-				usage.InputTokens += value
-			}
 		}
 	}
 	if value, ok := toInt(event["inputTokens"]); ok && value > 0 {

--- a/backend/internal/pkg/kiro/translator_test.go
+++ b/backend/internal/pkg/kiro/translator_test.go
@@ -504,7 +504,8 @@ func TestParseNonStreamingEventStream(t *testing.T) {
 	result, err := ParseNonStreamingEventStreamWithContext(stream, "claude-sonnet-4-5", KiroRequestContext{})
 	require.NoError(t, err)
 	require.Equal(t, "end_turn", result.StopReason)
-	require.Equal(t, 15, result.Usage.InputTokens)
+	require.Equal(t, 12, result.Usage.InputTokens)
+	require.Equal(t, 3, result.Usage.CacheReadInputTokens)
 	require.Equal(t, 7, result.Usage.OutputTokens)
 	require.Equal(t, 22, result.Usage.TotalTokens)
 


### PR DESCRIPTION
## 背景
Kiro 上游事件流里的 `cacheReadInputTokens` 在 `updateUsageFromEvent` 被错误地累加进了 `input_tokens`。而计费侧本来就把 `input_tokens` 和 `cache_read_input_tokens` 当两个独立字段分别计价，导致缓存命中的那部分 token 被按 input 单价（~$5/M 量级）多算了一遍，计费翻倍。

## 这次改了什么
- `translator.updateUsageFromEvent`：`cacheReadInputTokens` 只赋值给 `usage.CacheReadInputTokens`，不再累加进 `InputTokens`。
- 修正后 `input_tokens` 仅含未命中缓存的输入部分，对齐 Anthropic 标准 usage 语义；cache_read 由独立字段记账。
- 补充对应单测。

## 没有放进这次 PR 的内容
纯计数修正，不涉及计费规则、schema 或接口改动；不改变非 Kiro 平台行为。

## 验证
```
go test ./internal/pkg/kiro -run Kiro
```

## 线上验证建议
合入后用 Kiro 分组发请求，观察 `usage_logs` 的 `input_tokens` 不再包含 cache_read 部分，`total_cost` 相应下降（之前是多收的）。


🤖 Generated with [Claude Code](https://claude.com/claude-code)
