### PR TITLE
fix(kiro): sync 429 cooldown to DB and stop fallback from clobbering it

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1818,7 +1818,7 @@ func setDefaults() {
 	viper.SetDefault("gateway.log_upstream_error_body_max_bytes", 2048)
 	viper.SetDefault("gateway.inject_beta_for_apikey", false)
 	viper.SetDefault("gateway.failover_on_400", false)
-	viper.SetDefault("gateway.max_account_switches", 10)
+	viper.SetDefault("gateway.max_account_switches", 15)
 	viper.SetDefault("gateway.max_account_switches_gemini", 3)
 	viper.SetDefault("gateway.force_codex_cli", false)
 	viper.SetDefault("gateway.codex_image_generation_bridge_enabled", false)

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -98,7 +98,7 @@ func NewGatewayHandler(
 	settingService *service.SettingService,
 ) *GatewayHandler {
 	pingInterval := time.Duration(0)
-	maxAccountSwitches := 10
+	maxAccountSwitches := 15
 	maxAccountSwitchesGemini := 3
 	if cfg != nil {
 		pingInterval = time.Duration(cfg.Concurrency.PingInterval) * time.Second

--- a/backend/internal/service/kiro_runtime.go
+++ b/backend/internal/service/kiro_runtime.go
@@ -386,7 +386,9 @@ func (s *GatewayService) executeKiroUpstreamWithParsed(ctx context.Context, acco
 			}
 
 			if resp.StatusCode == http.StatusTooManyRequests {
-				cooldown, err := s.markKiro429(ctx, accountKey)
+				dumpKiro429ResponseForDebug(resp, account.ID, endpoint.URL, endpoint.Name)
+
+				cooldown, err := s.markKiro429(ctx, account.ID, accountKey)
 				if err != nil {
 					_ = resp.Body.Close()
 					return nil, requestCtx, err
@@ -496,7 +498,7 @@ func (s *GatewayService) executeKiroUpstreamWithParsed(ctx context.Context, acco
 			}
 
 			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-				if err := s.markKiroSuccess(ctx, accountKey); err != nil {
+				if err := s.markKiroSuccess(ctx, account.ID, accountKey); err != nil {
 					_ = resp.Body.Close()
 					return nil, requestCtx, err
 				}
@@ -776,6 +778,57 @@ func logKiroBadRequestClassification(classification kiroErrorClassification, acc
 		zap.String("model", strings.TrimSpace(model)),
 		zap.String("request_id", headers.Get("x-request-id")),
 		zap.String("body_excerpt", truncateForLog(body, 512)),
+	)
+}
+
+// dumpKiro429ResponseForDebug captures the first 2KB of a Kiro 429 response body
+// and the rate-limit-relevant headers, then restores resp.Body so the caller can
+// still consume it. Used to investigate whether Kiro returns a reset-time field
+// (e.g. nextDateReset) we should parse instead of falling back to fixed cooldown.
+func dumpKiro429ResponseForDebug(resp *http.Response, accountID int64, endpointURL, endpointName string) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	const maxBytes = 2048
+	limited := io.LimitReader(resp.Body, maxBytes+1)
+	sample, err := io.ReadAll(limited)
+	if err != nil {
+		logger.L().Warn("kiro.429_debug_read_failed",
+			zap.Int64("account_id", accountID),
+			zap.String("endpoint", endpointName),
+			zap.Error(err),
+		)
+		_ = resp.Body.Close()
+		resp.Body = io.NopCloser(bytes.NewReader(nil))
+		return
+	}
+	truncated := false
+	if len(sample) > maxBytes {
+		sample = sample[:maxBytes]
+		truncated = true
+	}
+	rest, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(append(append([]byte{}, sample...), rest...)))
+
+	headers := map[string]string{}
+	for k, v := range resp.Header {
+		lk := strings.ToLower(k)
+		if strings.Contains(lk, "ratelimit") || strings.Contains(lk, "retry") || strings.Contains(lk, "reset") ||
+			lk == "content-type" || lk == "x-amzn-requestid" || lk == "x-amzn-errortype" {
+			headers[k] = strings.Join(v, ",")
+		}
+	}
+
+	logger.L().Warn("kiro.429_raw_response",
+		zap.Int64("account_id", accountID),
+		zap.String("endpoint_url", endpointURL),
+		zap.String("endpoint_name", endpointName),
+		zap.String("content_type", resp.Header.Get("Content-Type")),
+		zap.Any("relevant_headers", headers),
+		zap.Int("body_bytes", len(sample)),
+		zap.Bool("truncated", truncated),
+		zap.String("body_sample", string(sample)),
 	)
 }
 

--- a/backend/internal/service/kiro_runtime.go
+++ b/backend/internal/service/kiro_runtime.go
@@ -688,7 +688,11 @@ func (s *GatewayService) handleKiroHTTPError(ctx context.Context, resp *http.Res
 			Kind:               "failover",
 			Message:            upstreamMsg,
 		})
-		if s.rateLimitService != nil {
+		// 429 已经被 executeKiroUpstreamWithParsed → markKiro429 完整处理（Redis 1-5min
+		// 指数退避 + DB rate_limit_reset_at 同步）。这里再走 HandleUpstreamError 会进入
+		// handle429 → apply429FallbackRateLimit，把 DB cooldown 反写成 5s flat，
+		// 直接抹掉我们刚算好的退避时长。所以 429 跳过通用 handler。
+		if s.rateLimitService != nil && resp.StatusCode != http.StatusTooManyRequests {
 			s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
 		}
 		return &UpstreamFailoverError{

--- a/backend/internal/service/kiro_runtime_state.go
+++ b/backend/internal/service/kiro_runtime_state.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/kirocooldown"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"go.uber.org/zap"
 )
 
 var errKiroCooldownStoreUnavailable = errors.New("kiro cooldown store unavailable")
@@ -57,18 +59,55 @@ func (s *GatewayService) checkAndWaitKiroCooldown(ctx context.Context, tokenKey 
 	}
 }
 
-func (s *GatewayService) markKiroSuccess(ctx context.Context, tokenKey string) error {
+// markKiroSuccess records a successful Kiro response. Pair with markKiro429:
+// because markKiro429 writes account.rate_limit_reset_at into DB, an account
+// that recovers (success) must also clear that DB field, otherwise the
+// scheduler keeps filtering the now-healthy account until the stale
+// rate_limit_reset_at naturally expires (up to 5min). accountID may be 0 for
+// callers that don't have it (Redis-only clear).
+func (s *GatewayService) markKiroSuccess(ctx context.Context, accountID int64, tokenKey string) error {
 	if s == nil || s.kiroCooldownStore == nil {
 		return errKiroCooldownStoreUnavailable
 	}
-	return s.kiroCooldownStore.MarkSuccess(ctx, tokenKey)
+	if err := s.kiroCooldownStore.MarkSuccess(ctx, tokenKey); err != nil {
+		return err
+	}
+	if s.accountRepo != nil && accountID > 0 {
+		if dbErr := s.accountRepo.ClearRateLimit(ctx, accountID); dbErr != nil {
+			logger.L().Warn("kiro.mark_success_db_clear_failed",
+				zap.Int64("account_id", accountID),
+				zap.Error(dbErr),
+			)
+		}
+	}
+	return nil
 }
 
-func (s *GatewayService) markKiro429(ctx context.Context, tokenKey string) (time.Duration, error) {
+// markKiro429 records a Kiro 429 in both Redis (kiroCooldownStore) and DB
+// (account.rate_limit_reset_at). Syncing to DB is critical: without it,
+// ListSchedulable* still returns this account as schedulable, so the failover
+// loop keeps re-picking it just to bounce off the Redis gate (asKiroCooldownFailoverError)
+// — burning failover slots and amplifying retry storms. accountID may be 0 for
+// callers that don't have it; we fall back to Redis-only.
+func (s *GatewayService) markKiro429(ctx context.Context, accountID int64, tokenKey string) (time.Duration, error) {
 	if s == nil || s.kiroCooldownStore == nil {
 		return 0, errKiroCooldownStoreUnavailable
 	}
-	return s.kiroCooldownStore.Mark429(ctx, tokenKey)
+	cooldown, err := s.kiroCooldownStore.Mark429(ctx, tokenKey)
+	if err != nil {
+		return 0, err
+	}
+	if s.accountRepo != nil && accountID > 0 && cooldown > 0 {
+		resetAt := time.Now().Add(cooldown)
+		if dbErr := s.accountRepo.SetRateLimited(ctx, accountID, resetAt); dbErr != nil {
+			logger.L().Warn("kiro.mark_429_db_sync_failed",
+				zap.Int64("account_id", accountID),
+				zap.Duration("cooldown", cooldown),
+				zap.Error(dbErr),
+			)
+		}
+	}
+	return cooldown, nil
 }
 
 func (s *GatewayService) markKiroSuspended(ctx context.Context, tokenKey string) (time.Duration, error) {

--- a/backend/internal/service/kiro_runtime_state_test.go
+++ b/backend/internal/service/kiro_runtime_state_test.go
@@ -44,6 +44,14 @@ type recordingKiroTempUnschedRepo struct {
 	rateID          int64
 	rateLimitReset  time.Time
 	rateLimitedCall int
+	clearCalled     bool
+	clearID         int64
+}
+
+func (r *recordingKiroTempUnschedRepo) ClearRateLimit(_ context.Context, id int64) error {
+	r.clearCalled = true
+	r.clearID = id
+	return nil
 }
 
 func (r *recordingKiroTempUnschedRepo) SetTempUnschedulable(_ context.Context, id int64, until time.Time, reason string) error {
@@ -103,6 +111,88 @@ func (s *stubKiroCooldownStore) ClearEarliestTransientCooldown(_ context.Context
 	s.clearCalled = true
 	s.clearKeys = append([]string(nil), tokenKeys...)
 	return s.clearResult, s.clearErr
+}
+
+func TestMarkKiro429SyncsDBRateLimitResetAt(t *testing.T) {
+	cooldown := 90 * time.Second
+	repo := &recordingKiroTempUnschedRepo{}
+	svc := &GatewayService{
+		accountRepo:       repo,
+		kiroCooldownStore: &stubKiroCooldownStore{mark429TTL: cooldown},
+	}
+
+	before := time.Now()
+	got, err := svc.markKiro429(context.Background(), 42, "token1")
+	require.NoError(t, err)
+	require.Equal(t, cooldown, got)
+	require.True(t, repo.rateCalled, "expected SetRateLimited to be called so DB scheduler skips the account")
+	require.Equal(t, int64(42), repo.rateID)
+	// resetAt must land inside [now+cooldown, now+cooldown+slack]
+	min := before.Add(cooldown)
+	max := time.Now().Add(cooldown + 100*time.Millisecond)
+	require.False(t, repo.rateLimitReset.Before(min), "resetAt %s before expected min %s", repo.rateLimitReset, min)
+	require.False(t, repo.rateLimitReset.After(max), "resetAt %s after expected max %s", repo.rateLimitReset, max)
+}
+
+func TestMarkKiro429SkipsDBSyncWhenAccountIDZero(t *testing.T) {
+	repo := &recordingKiroTempUnschedRepo{}
+	svc := &GatewayService{
+		accountRepo:       repo,
+		kiroCooldownStore: &stubKiroCooldownStore{mark429TTL: time.Minute},
+	}
+
+	_, err := svc.markKiro429(context.Background(), 0, "token1")
+	require.NoError(t, err)
+	require.False(t, repo.rateCalled, "should not write DB when accountID is unknown")
+}
+
+func TestMarkKiroSuccessClearsDBRateLimit(t *testing.T) {
+	repo := &recordingKiroTempUnschedRepo{}
+	svc := &GatewayService{
+		accountRepo:       repo,
+		kiroCooldownStore: &stubKiroCooldownStore{},
+	}
+
+	require.NoError(t, svc.markKiroSuccess(context.Background(), 42, "token1"))
+	require.True(t, repo.clearCalled, "expected ClearRateLimit so a recovered Kiro account becomes schedulable immediately")
+	require.Equal(t, int64(42), repo.clearID)
+}
+
+func TestMarkKiroSuccessSkipsDBClearWhenAccountIDZero(t *testing.T) {
+	repo := &recordingKiroTempUnschedRepo{}
+	svc := &GatewayService{
+		accountRepo:       repo,
+		kiroCooldownStore: &stubKiroCooldownStore{},
+	}
+
+	require.NoError(t, svc.markKiroSuccess(context.Background(), 0, "token1"))
+	require.False(t, repo.clearCalled, "should not clear DB when accountID is unknown")
+}
+
+func TestMarkKiroSuccessSkipsDBClearWhenRedisFails(t *testing.T) {
+	expected := errors.New("redis exploded")
+	repo := &recordingKiroTempUnschedRepo{}
+	svc := &GatewayService{
+		accountRepo:       repo,
+		kiroCooldownStore: &stubKiroCooldownStore{successErr: expected},
+	}
+
+	err := svc.markKiroSuccess(context.Background(), 42, "token1")
+	require.ErrorIs(t, err, expected)
+	require.False(t, repo.clearCalled, "DB clear must not run when Redis MarkSuccess failed")
+}
+
+func TestMarkKiro429PropagatesRedisError(t *testing.T) {
+	expected := errors.New("redis exploded")
+	repo := &recordingKiroTempUnschedRepo{}
+	svc := &GatewayService{
+		accountRepo:       repo,
+		kiroCooldownStore: &stubKiroCooldownStore{mark429Err: expected},
+	}
+
+	_, err := svc.markKiro429(context.Background(), 42, "token1")
+	require.ErrorIs(t, err, expected)
+	require.False(t, repo.rateCalled, "DB sync must not run when Redis Mark429 failed")
 }
 
 func TestCalculateKiro429Cooldown(t *testing.T) {

--- a/backend/internal/service/kiro_websearch.go
+++ b/backend/internal/service/kiro_websearch.go
@@ -440,7 +440,7 @@ func (s *GatewayService) doKiroMCPJSONRequest(ctx context.Context, account *Acco
 		}
 
 		if resp.StatusCode == http.StatusTooManyRequests {
-			if _, err := s.markKiro429(ctx, accountKey); err != nil {
+			if _, err := s.markKiro429(ctx, account.ID, accountKey); err != nil {
 				_ = resp.Body.Close()
 				return nil, currentToken, err
 			}
@@ -455,7 +455,7 @@ func (s *GatewayService) doKiroMCPJSONRequest(ctx context.Context, account *Acco
 			}
 		}
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-			if err := s.markKiroSuccess(ctx, accountKey); err != nil {
+			if err := s.markKiroSuccess(ctx, account.ID, accountKey); err != nil {
 				_ = resp.Body.Close()
 				return nil, currentToken, err
 			}


### PR DESCRIPTION
## 背景
Kiro 账号命中上游 429 时，cooldown 只记在 Redis（kirocooldown），没回写 `account.rate_limit_reset_at`。但 `ListSchedulable*` 按 DB 字段筛账号，导致冷却中的账号在 DB 视角仍可调度 → failover 反复选回它 → 撞 Redis 闸门失败 → 再 failover……烧光切换次数、放大 retry storm。另外 `handleKiroHTTPError` 把 429 也交给通用 `HandleUpstreamError`，其 fallback 用 5s flat reset 覆盖掉刚写入的指数退避 cooldown，账号 5s 后又被调度，客户端连环 429。

## 这次改了什么
- `markKiro429` 增加 accountID 参数，Redis 记账成功后同步 `accountRepo.SetRateLimited`（resetAt = now + cooldown），调度器立即过滤该账号。
- `markKiroSuccess` 对称增加 accountID + `accountRepo.ClearRateLimit`，否则账号恢复后会被残留的 reset_at 多过滤一个冷却窗口。
- `handleKiroHTTPError` 对 429 跳过 `HandleUpstreamError`，让 429 完全由 markKiro429 路径接管（其它错误码行为不变）。
- 新增 `dumpKiroResponseForDebug`：记录 429 响应 body 前 2KB + rate-limit headers，为后续自适应退避做数据准备。
- `max_account_switches` 默认 10 → 15（多账号冷却场景 10 次不够 sticky miss 后的 failover）。

## 没有放进这次 PR 的内容
没有实现"读取 Kiro 429 响应里的 reset hint 做自适应退避"——这次只把响应抓进日志，退避曲线仍是固定指数。

## 验证
```
go test -tags=unit ./internal/service -run 'MarkKiro|HandleKiroHTTPError'
go test ./internal/service -run Kiro
```
（6 个新单测覆盖 DB 同步 / accountID=0 跳过 / Redis 失败不写 DB / Success 对称清除）

## 线上验证建议
制造一次 Kiro 429，观察：账号的 `rate_limit_reset_at` 被写入；failover 不再反复选中该账号；冷却到期后请求恢复正常，无 5s 后的连环 429。


🤖 Generated with [Claude Code](https://claude.com/claude-code)
