### PR TITLE
feat(kiro): reverse token scaling billing anchored to real credits

### DIFF
--- a/backend/ent/group.go
+++ b/backend/ent/group.go
@@ -97,6 +97,8 @@ type Group struct {
 	KiroStickySessionTTLSeconds int `json:"kiro_sticky_session_ttl_seconds,omitempty"`
 	// Kiro 模拟缓存生效比例，范围 0-1（仅 kiro 分组生效）
 	KiroCacheEmulationRatio float64 `json:"kiro_cache_emulation_ratio,omitempty"`
+	// Kiro 反向 token 缩放锚定单价：每 credit 对应 USD 余额（0=禁用）
+	KiroCreditTargetUsd float64 `json:"kiro_credit_target_usd,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the GroupQuery when eager-loading is set.
 	Edges        GroupEdges `json:"edges"`
@@ -207,7 +209,7 @@ func (*Group) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case group.FieldIsExclusive, group.FieldAllowImageGeneration, group.FieldImageRateIndependent, group.FieldClaudeCodeOnly, group.FieldModelRoutingEnabled, group.FieldMcpXMLInject, group.FieldAllowMessagesDispatch, group.FieldRequireOauthOnly, group.FieldRequirePrivacySet, group.FieldKiroCacheEmulationEnabled, group.FieldKiroAutoStickyEnabled:
 			values[i] = new(sql.NullBool)
-		case group.FieldRateMultiplier, group.FieldDailyLimitUsd, group.FieldWeeklyLimitUsd, group.FieldMonthlyLimitUsd, group.FieldImageRateMultiplier, group.FieldImagePrice1k, group.FieldImagePrice2k, group.FieldImagePrice4k, group.FieldKiroCacheEmulationRatio:
+		case group.FieldRateMultiplier, group.FieldDailyLimitUsd, group.FieldWeeklyLimitUsd, group.FieldMonthlyLimitUsd, group.FieldImageRateMultiplier, group.FieldImagePrice1k, group.FieldImagePrice2k, group.FieldImagePrice4k, group.FieldKiroCacheEmulationRatio, group.FieldKiroCreditTargetUsd:
 			values[i] = new(sql.NullFloat64)
 		case group.FieldID, group.FieldDefaultValidityDays, group.FieldFallbackGroupID, group.FieldFallbackGroupIDOnInvalidRequest, group.FieldSortOrder, group.FieldRpmLimit, group.FieldKiroStickySessionTTLSeconds:
 			values[i] = new(sql.NullInt64)
@@ -488,6 +490,12 @@ func (_m *Group) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.KiroCacheEmulationRatio = value.Float64
 			}
+		case group.FieldKiroCreditTargetUsd:
+			if value, ok := values[i].(*sql.NullFloat64); !ok {
+				return fmt.Errorf("unexpected type %T for field kiro_credit_target_usd", values[i])
+			} else if value.Valid {
+				_m.KiroCreditTargetUsd = value.Float64
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -700,6 +708,9 @@ func (_m *Group) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("kiro_cache_emulation_ratio=")
 	builder.WriteString(fmt.Sprintf("%v", _m.KiroCacheEmulationRatio))
+	builder.WriteString(", ")
+	builder.WriteString("kiro_credit_target_usd=")
+	builder.WriteString(fmt.Sprintf("%v", _m.KiroCreditTargetUsd))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/backend/ent/group.go
+++ b/backend/ent/group.go
@@ -99,6 +99,8 @@ type Group struct {
 	KiroCacheEmulationRatio float64 `json:"kiro_cache_emulation_ratio,omitempty"`
 	// Kiro 反向 token 缩放锚定单价：每 credit 对应 USD 余额（0=禁用）
 	KiroCreditTargetUsd float64 `json:"kiro_credit_target_usd,omitempty"`
+	// Kiro 缓存强制比例中位数（0=禁用）。>0 时把模拟缓存分布重塑成 Anthropic-like 形态（input 极小、cache_read 占大头）；配合 credit 反向缩放计费时为纯展示口径，不改变最终扣费（=credits×单价）
+	KiroCacheForceRatioCenter float64 `json:"kiro_cache_force_ratio_center,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the GroupQuery when eager-loading is set.
 	Edges        GroupEdges `json:"edges"`
@@ -209,7 +211,7 @@ func (*Group) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case group.FieldIsExclusive, group.FieldAllowImageGeneration, group.FieldImageRateIndependent, group.FieldClaudeCodeOnly, group.FieldModelRoutingEnabled, group.FieldMcpXMLInject, group.FieldAllowMessagesDispatch, group.FieldRequireOauthOnly, group.FieldRequirePrivacySet, group.FieldKiroCacheEmulationEnabled, group.FieldKiroAutoStickyEnabled:
 			values[i] = new(sql.NullBool)
-		case group.FieldRateMultiplier, group.FieldDailyLimitUsd, group.FieldWeeklyLimitUsd, group.FieldMonthlyLimitUsd, group.FieldImageRateMultiplier, group.FieldImagePrice1k, group.FieldImagePrice2k, group.FieldImagePrice4k, group.FieldKiroCacheEmulationRatio, group.FieldKiroCreditTargetUsd:
+		case group.FieldRateMultiplier, group.FieldDailyLimitUsd, group.FieldWeeklyLimitUsd, group.FieldMonthlyLimitUsd, group.FieldImageRateMultiplier, group.FieldImagePrice1k, group.FieldImagePrice2k, group.FieldImagePrice4k, group.FieldKiroCacheEmulationRatio, group.FieldKiroCreditTargetUsd, group.FieldKiroCacheForceRatioCenter:
 			values[i] = new(sql.NullFloat64)
 		case group.FieldID, group.FieldDefaultValidityDays, group.FieldFallbackGroupID, group.FieldFallbackGroupIDOnInvalidRequest, group.FieldSortOrder, group.FieldRpmLimit, group.FieldKiroStickySessionTTLSeconds:
 			values[i] = new(sql.NullInt64)
@@ -496,6 +498,12 @@ func (_m *Group) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.KiroCreditTargetUsd = value.Float64
 			}
+		case group.FieldKiroCacheForceRatioCenter:
+			if value, ok := values[i].(*sql.NullFloat64); !ok {
+				return fmt.Errorf("unexpected type %T for field kiro_cache_force_ratio_center", values[i])
+			} else if value.Valid {
+				_m.KiroCacheForceRatioCenter = value.Float64
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -711,6 +719,9 @@ func (_m *Group) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("kiro_credit_target_usd=")
 	builder.WriteString(fmt.Sprintf("%v", _m.KiroCreditTargetUsd))
+	builder.WriteString(", ")
+	builder.WriteString("kiro_cache_force_ratio_center=")
+	builder.WriteString(fmt.Sprintf("%v", _m.KiroCacheForceRatioCenter))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/backend/ent/group/group.go
+++ b/backend/ent/group/group.go
@@ -96,6 +96,8 @@ const (
 	FieldKiroCacheEmulationRatio = "kiro_cache_emulation_ratio"
 	// FieldKiroCreditTargetUsd holds the string denoting the kiro_credit_target_usd field in the database.
 	FieldKiroCreditTargetUsd = "kiro_credit_target_usd"
+	// FieldKiroCacheForceRatioCenter holds the string denoting the kiro_cache_force_ratio_center field in the database.
+	FieldKiroCacheForceRatioCenter = "kiro_cache_force_ratio_center"
 	// EdgeAPIKeys holds the string denoting the api_keys edge name in mutations.
 	EdgeAPIKeys = "api_keys"
 	// EdgeRedeemCodes holds the string denoting the redeem_codes edge name in mutations.
@@ -211,6 +213,7 @@ var Columns = []string{
 	FieldKiroStickySessionTTLSeconds,
 	FieldKiroCacheEmulationRatio,
 	FieldKiroCreditTargetUsd,
+	FieldKiroCacheForceRatioCenter,
 }
 
 var (
@@ -308,6 +311,8 @@ var (
 	DefaultKiroCacheEmulationRatio float64
 	// DefaultKiroCreditTargetUsd holds the default value on creation for the "kiro_credit_target_usd" field.
 	DefaultKiroCreditTargetUsd float64
+	// DefaultKiroCacheForceRatioCenter holds the default value on creation for the "kiro_cache_force_ratio_center" field.
+	DefaultKiroCacheForceRatioCenter float64
 )
 
 // OrderOption defines the ordering options for the Group queries.
@@ -496,6 +501,11 @@ func ByKiroCacheEmulationRatio(opts ...sql.OrderTermOption) OrderOption {
 // ByKiroCreditTargetUsd orders the results by the kiro_credit_target_usd field.
 func ByKiroCreditTargetUsd(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldKiroCreditTargetUsd, opts...).ToFunc()
+}
+
+// ByKiroCacheForceRatioCenter orders the results by the kiro_cache_force_ratio_center field.
+func ByKiroCacheForceRatioCenter(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldKiroCacheForceRatioCenter, opts...).ToFunc()
 }
 
 // ByAPIKeysCount orders the results by api_keys count.

--- a/backend/ent/group/group.go
+++ b/backend/ent/group/group.go
@@ -94,6 +94,8 @@ const (
 	FieldKiroStickySessionTTLSeconds = "kiro_sticky_session_ttl_seconds"
 	// FieldKiroCacheEmulationRatio holds the string denoting the kiro_cache_emulation_ratio field in the database.
 	FieldKiroCacheEmulationRatio = "kiro_cache_emulation_ratio"
+	// FieldKiroCreditTargetUsd holds the string denoting the kiro_credit_target_usd field in the database.
+	FieldKiroCreditTargetUsd = "kiro_credit_target_usd"
 	// EdgeAPIKeys holds the string denoting the api_keys edge name in mutations.
 	EdgeAPIKeys = "api_keys"
 	// EdgeRedeemCodes holds the string denoting the redeem_codes edge name in mutations.
@@ -208,6 +210,7 @@ var Columns = []string{
 	FieldKiroAutoStickyEnabled,
 	FieldKiroStickySessionTTLSeconds,
 	FieldKiroCacheEmulationRatio,
+	FieldKiroCreditTargetUsd,
 }
 
 var (
@@ -303,6 +306,8 @@ var (
 	DefaultKiroStickySessionTTLSeconds int
 	// DefaultKiroCacheEmulationRatio holds the default value on creation for the "kiro_cache_emulation_ratio" field.
 	DefaultKiroCacheEmulationRatio float64
+	// DefaultKiroCreditTargetUsd holds the default value on creation for the "kiro_credit_target_usd" field.
+	DefaultKiroCreditTargetUsd float64
 )
 
 // OrderOption defines the ordering options for the Group queries.
@@ -486,6 +491,11 @@ func ByKiroStickySessionTTLSeconds(opts ...sql.OrderTermOption) OrderOption {
 // ByKiroCacheEmulationRatio orders the results by the kiro_cache_emulation_ratio field.
 func ByKiroCacheEmulationRatio(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldKiroCacheEmulationRatio, opts...).ToFunc()
+}
+
+// ByKiroCreditTargetUsd orders the results by the kiro_credit_target_usd field.
+func ByKiroCreditTargetUsd(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldKiroCreditTargetUsd, opts...).ToFunc()
 }
 
 // ByAPIKeysCount orders the results by api_keys count.

--- a/backend/ent/group/where.go
+++ b/backend/ent/group/where.go
@@ -235,6 +235,11 @@ func KiroCreditTargetUsd(v float64) predicate.Group {
 	return predicate.Group(sql.FieldEQ(FieldKiroCreditTargetUsd, v))
 }
 
+// KiroCacheForceRatioCenter applies equality check predicate on the "kiro_cache_force_ratio_center" field. It's identical to KiroCacheForceRatioCenterEQ.
+func KiroCacheForceRatioCenter(v float64) predicate.Group {
+	return predicate.Group(sql.FieldEQ(FieldKiroCacheForceRatioCenter, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Group {
 	return predicate.Group(sql.FieldEQ(FieldCreatedAt, v))
@@ -1603,6 +1608,46 @@ func KiroCreditTargetUsdLT(v float64) predicate.Group {
 // KiroCreditTargetUsdLTE applies the LTE predicate on the "kiro_credit_target_usd" field.
 func KiroCreditTargetUsdLTE(v float64) predicate.Group {
 	return predicate.Group(sql.FieldLTE(FieldKiroCreditTargetUsd, v))
+}
+
+// KiroCacheForceRatioCenterEQ applies the EQ predicate on the "kiro_cache_force_ratio_center" field.
+func KiroCacheForceRatioCenterEQ(v float64) predicate.Group {
+	return predicate.Group(sql.FieldEQ(FieldKiroCacheForceRatioCenter, v))
+}
+
+// KiroCacheForceRatioCenterNEQ applies the NEQ predicate on the "kiro_cache_force_ratio_center" field.
+func KiroCacheForceRatioCenterNEQ(v float64) predicate.Group {
+	return predicate.Group(sql.FieldNEQ(FieldKiroCacheForceRatioCenter, v))
+}
+
+// KiroCacheForceRatioCenterIn applies the In predicate on the "kiro_cache_force_ratio_center" field.
+func KiroCacheForceRatioCenterIn(vs ...float64) predicate.Group {
+	return predicate.Group(sql.FieldIn(FieldKiroCacheForceRatioCenter, vs...))
+}
+
+// KiroCacheForceRatioCenterNotIn applies the NotIn predicate on the "kiro_cache_force_ratio_center" field.
+func KiroCacheForceRatioCenterNotIn(vs ...float64) predicate.Group {
+	return predicate.Group(sql.FieldNotIn(FieldKiroCacheForceRatioCenter, vs...))
+}
+
+// KiroCacheForceRatioCenterGT applies the GT predicate on the "kiro_cache_force_ratio_center" field.
+func KiroCacheForceRatioCenterGT(v float64) predicate.Group {
+	return predicate.Group(sql.FieldGT(FieldKiroCacheForceRatioCenter, v))
+}
+
+// KiroCacheForceRatioCenterGTE applies the GTE predicate on the "kiro_cache_force_ratio_center" field.
+func KiroCacheForceRatioCenterGTE(v float64) predicate.Group {
+	return predicate.Group(sql.FieldGTE(FieldKiroCacheForceRatioCenter, v))
+}
+
+// KiroCacheForceRatioCenterLT applies the LT predicate on the "kiro_cache_force_ratio_center" field.
+func KiroCacheForceRatioCenterLT(v float64) predicate.Group {
+	return predicate.Group(sql.FieldLT(FieldKiroCacheForceRatioCenter, v))
+}
+
+// KiroCacheForceRatioCenterLTE applies the LTE predicate on the "kiro_cache_force_ratio_center" field.
+func KiroCacheForceRatioCenterLTE(v float64) predicate.Group {
+	return predicate.Group(sql.FieldLTE(FieldKiroCacheForceRatioCenter, v))
 }
 
 // HasAPIKeys applies the HasEdge predicate on the "api_keys" edge.

--- a/backend/ent/group/where.go
+++ b/backend/ent/group/where.go
@@ -230,6 +230,11 @@ func KiroCacheEmulationRatio(v float64) predicate.Group {
 	return predicate.Group(sql.FieldEQ(FieldKiroCacheEmulationRatio, v))
 }
 
+// KiroCreditTargetUsd applies equality check predicate on the "kiro_credit_target_usd" field. It's identical to KiroCreditTargetUsdEQ.
+func KiroCreditTargetUsd(v float64) predicate.Group {
+	return predicate.Group(sql.FieldEQ(FieldKiroCreditTargetUsd, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Group {
 	return predicate.Group(sql.FieldEQ(FieldCreatedAt, v))
@@ -1558,6 +1563,46 @@ func KiroCacheEmulationRatioLT(v float64) predicate.Group {
 // KiroCacheEmulationRatioLTE applies the LTE predicate on the "kiro_cache_emulation_ratio" field.
 func KiroCacheEmulationRatioLTE(v float64) predicate.Group {
 	return predicate.Group(sql.FieldLTE(FieldKiroCacheEmulationRatio, v))
+}
+
+// KiroCreditTargetUsdEQ applies the EQ predicate on the "kiro_credit_target_usd" field.
+func KiroCreditTargetUsdEQ(v float64) predicate.Group {
+	return predicate.Group(sql.FieldEQ(FieldKiroCreditTargetUsd, v))
+}
+
+// KiroCreditTargetUsdNEQ applies the NEQ predicate on the "kiro_credit_target_usd" field.
+func KiroCreditTargetUsdNEQ(v float64) predicate.Group {
+	return predicate.Group(sql.FieldNEQ(FieldKiroCreditTargetUsd, v))
+}
+
+// KiroCreditTargetUsdIn applies the In predicate on the "kiro_credit_target_usd" field.
+func KiroCreditTargetUsdIn(vs ...float64) predicate.Group {
+	return predicate.Group(sql.FieldIn(FieldKiroCreditTargetUsd, vs...))
+}
+
+// KiroCreditTargetUsdNotIn applies the NotIn predicate on the "kiro_credit_target_usd" field.
+func KiroCreditTargetUsdNotIn(vs ...float64) predicate.Group {
+	return predicate.Group(sql.FieldNotIn(FieldKiroCreditTargetUsd, vs...))
+}
+
+// KiroCreditTargetUsdGT applies the GT predicate on the "kiro_credit_target_usd" field.
+func KiroCreditTargetUsdGT(v float64) predicate.Group {
+	return predicate.Group(sql.FieldGT(FieldKiroCreditTargetUsd, v))
+}
+
+// KiroCreditTargetUsdGTE applies the GTE predicate on the "kiro_credit_target_usd" field.
+func KiroCreditTargetUsdGTE(v float64) predicate.Group {
+	return predicate.Group(sql.FieldGTE(FieldKiroCreditTargetUsd, v))
+}
+
+// KiroCreditTargetUsdLT applies the LT predicate on the "kiro_credit_target_usd" field.
+func KiroCreditTargetUsdLT(v float64) predicate.Group {
+	return predicate.Group(sql.FieldLT(FieldKiroCreditTargetUsd, v))
+}
+
+// KiroCreditTargetUsdLTE applies the LTE predicate on the "kiro_credit_target_usd" field.
+func KiroCreditTargetUsdLTE(v float64) predicate.Group {
+	return predicate.Group(sql.FieldLTE(FieldKiroCreditTargetUsd, v))
 }
 
 // HasAPIKeys applies the HasEdge predicate on the "api_keys" edge.

--- a/backend/ent/group_create.go
+++ b/backend/ent/group_create.go
@@ -565,6 +565,20 @@ func (_c *GroupCreate) SetNillableKiroCreditTargetUsd(v *float64) *GroupCreate {
 	return _c
 }
 
+// SetKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field.
+func (_c *GroupCreate) SetKiroCacheForceRatioCenter(v float64) *GroupCreate {
+	_c.mutation.SetKiroCacheForceRatioCenter(v)
+	return _c
+}
+
+// SetNillableKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field if the given value is not nil.
+func (_c *GroupCreate) SetNillableKiroCacheForceRatioCenter(v *float64) *GroupCreate {
+	if v != nil {
+		_c.SetKiroCacheForceRatioCenter(*v)
+	}
+	return _c
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by IDs.
 func (_c *GroupCreate) AddAPIKeyIDs(ids ...int64) *GroupCreate {
 	_c.mutation.AddAPIKeyIDs(ids...)
@@ -810,6 +824,10 @@ func (_c *GroupCreate) defaults() error {
 		v := group.DefaultKiroCreditTargetUsd
 		_c.mutation.SetKiroCreditTargetUsd(v)
 	}
+	if _, ok := _c.mutation.KiroCacheForceRatioCenter(); !ok {
+		v := group.DefaultKiroCacheForceRatioCenter
+		_c.mutation.SetKiroCacheForceRatioCenter(v)
+	}
 	return nil
 }
 
@@ -926,6 +944,9 @@ func (_c *GroupCreate) check() error {
 	}
 	if _, ok := _c.mutation.KiroCreditTargetUsd(); !ok {
 		return &ValidationError{Name: "kiro_credit_target_usd", err: errors.New(`ent: missing required field "Group.kiro_credit_target_usd"`)}
+	}
+	if _, ok := _c.mutation.KiroCacheForceRatioCenter(); !ok {
+		return &ValidationError{Name: "kiro_cache_force_ratio_center", err: errors.New(`ent: missing required field "Group.kiro_cache_force_ratio_center"`)}
 	}
 	return nil
 }
@@ -1113,6 +1134,10 @@ func (_c *GroupCreate) createSpec() (*Group, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.KiroCreditTargetUsd(); ok {
 		_spec.SetField(group.FieldKiroCreditTargetUsd, field.TypeFloat64, value)
 		_node.KiroCreditTargetUsd = value
+	}
+	if value, ok := _c.mutation.KiroCacheForceRatioCenter(); ok {
+		_spec.SetField(group.FieldKiroCacheForceRatioCenter, field.TypeFloat64, value)
+		_node.KiroCacheForceRatioCenter = value
 	}
 	if nodes := _c.mutation.APIKeysIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1900,6 +1925,24 @@ func (u *GroupUpsert) AddKiroCreditTargetUsd(v float64) *GroupUpsert {
 	return u
 }
 
+// SetKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field.
+func (u *GroupUpsert) SetKiroCacheForceRatioCenter(v float64) *GroupUpsert {
+	u.Set(group.FieldKiroCacheForceRatioCenter, v)
+	return u
+}
+
+// UpdateKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field to the value that was provided on create.
+func (u *GroupUpsert) UpdateKiroCacheForceRatioCenter() *GroupUpsert {
+	u.SetExcluded(group.FieldKiroCacheForceRatioCenter)
+	return u
+}
+
+// AddKiroCacheForceRatioCenter adds v to the "kiro_cache_force_ratio_center" field.
+func (u *GroupUpsert) AddKiroCacheForceRatioCenter(v float64) *GroupUpsert {
+	u.Add(group.FieldKiroCacheForceRatioCenter, v)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create.
 // Using this option is equivalent to using:
 //
@@ -2677,6 +2720,27 @@ func (u *GroupUpsertOne) AddKiroCreditTargetUsd(v float64) *GroupUpsertOne {
 func (u *GroupUpsertOne) UpdateKiroCreditTargetUsd() *GroupUpsertOne {
 	return u.Update(func(s *GroupUpsert) {
 		s.UpdateKiroCreditTargetUsd()
+	})
+}
+
+// SetKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field.
+func (u *GroupUpsertOne) SetKiroCacheForceRatioCenter(v float64) *GroupUpsertOne {
+	return u.Update(func(s *GroupUpsert) {
+		s.SetKiroCacheForceRatioCenter(v)
+	})
+}
+
+// AddKiroCacheForceRatioCenter adds v to the "kiro_cache_force_ratio_center" field.
+func (u *GroupUpsertOne) AddKiroCacheForceRatioCenter(v float64) *GroupUpsertOne {
+	return u.Update(func(s *GroupUpsert) {
+		s.AddKiroCacheForceRatioCenter(v)
+	})
+}
+
+// UpdateKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field to the value that was provided on create.
+func (u *GroupUpsertOne) UpdateKiroCacheForceRatioCenter() *GroupUpsertOne {
+	return u.Update(func(s *GroupUpsert) {
+		s.UpdateKiroCacheForceRatioCenter()
 	})
 }
 
@@ -3623,6 +3687,27 @@ func (u *GroupUpsertBulk) AddKiroCreditTargetUsd(v float64) *GroupUpsertBulk {
 func (u *GroupUpsertBulk) UpdateKiroCreditTargetUsd() *GroupUpsertBulk {
 	return u.Update(func(s *GroupUpsert) {
 		s.UpdateKiroCreditTargetUsd()
+	})
+}
+
+// SetKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field.
+func (u *GroupUpsertBulk) SetKiroCacheForceRatioCenter(v float64) *GroupUpsertBulk {
+	return u.Update(func(s *GroupUpsert) {
+		s.SetKiroCacheForceRatioCenter(v)
+	})
+}
+
+// AddKiroCacheForceRatioCenter adds v to the "kiro_cache_force_ratio_center" field.
+func (u *GroupUpsertBulk) AddKiroCacheForceRatioCenter(v float64) *GroupUpsertBulk {
+	return u.Update(func(s *GroupUpsert) {
+		s.AddKiroCacheForceRatioCenter(v)
+	})
+}
+
+// UpdateKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field to the value that was provided on create.
+func (u *GroupUpsertBulk) UpdateKiroCacheForceRatioCenter() *GroupUpsertBulk {
+	return u.Update(func(s *GroupUpsert) {
+		s.UpdateKiroCacheForceRatioCenter()
 	})
 }
 

--- a/backend/ent/group_create.go
+++ b/backend/ent/group_create.go
@@ -551,6 +551,20 @@ func (_c *GroupCreate) SetNillableKiroCacheEmulationRatio(v *float64) *GroupCrea
 	return _c
 }
 
+// SetKiroCreditTargetUsd sets the "kiro_credit_target_usd" field.
+func (_c *GroupCreate) SetKiroCreditTargetUsd(v float64) *GroupCreate {
+	_c.mutation.SetKiroCreditTargetUsd(v)
+	return _c
+}
+
+// SetNillableKiroCreditTargetUsd sets the "kiro_credit_target_usd" field if the given value is not nil.
+func (_c *GroupCreate) SetNillableKiroCreditTargetUsd(v *float64) *GroupCreate {
+	if v != nil {
+		_c.SetKiroCreditTargetUsd(*v)
+	}
+	return _c
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by IDs.
 func (_c *GroupCreate) AddAPIKeyIDs(ids ...int64) *GroupCreate {
 	_c.mutation.AddAPIKeyIDs(ids...)
@@ -792,6 +806,10 @@ func (_c *GroupCreate) defaults() error {
 		v := group.DefaultKiroCacheEmulationRatio
 		_c.mutation.SetKiroCacheEmulationRatio(v)
 	}
+	if _, ok := _c.mutation.KiroCreditTargetUsd(); !ok {
+		v := group.DefaultKiroCreditTargetUsd
+		_c.mutation.SetKiroCreditTargetUsd(v)
+	}
 	return nil
 }
 
@@ -905,6 +923,9 @@ func (_c *GroupCreate) check() error {
 	}
 	if _, ok := _c.mutation.KiroCacheEmulationRatio(); !ok {
 		return &ValidationError{Name: "kiro_cache_emulation_ratio", err: errors.New(`ent: missing required field "Group.kiro_cache_emulation_ratio"`)}
+	}
+	if _, ok := _c.mutation.KiroCreditTargetUsd(); !ok {
+		return &ValidationError{Name: "kiro_credit_target_usd", err: errors.New(`ent: missing required field "Group.kiro_credit_target_usd"`)}
 	}
 	return nil
 }
@@ -1088,6 +1109,10 @@ func (_c *GroupCreate) createSpec() (*Group, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.KiroCacheEmulationRatio(); ok {
 		_spec.SetField(group.FieldKiroCacheEmulationRatio, field.TypeFloat64, value)
 		_node.KiroCacheEmulationRatio = value
+	}
+	if value, ok := _c.mutation.KiroCreditTargetUsd(); ok {
+		_spec.SetField(group.FieldKiroCreditTargetUsd, field.TypeFloat64, value)
+		_node.KiroCreditTargetUsd = value
 	}
 	if nodes := _c.mutation.APIKeysIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1857,6 +1882,24 @@ func (u *GroupUpsert) AddKiroCacheEmulationRatio(v float64) *GroupUpsert {
 	return u
 }
 
+// SetKiroCreditTargetUsd sets the "kiro_credit_target_usd" field.
+func (u *GroupUpsert) SetKiroCreditTargetUsd(v float64) *GroupUpsert {
+	u.Set(group.FieldKiroCreditTargetUsd, v)
+	return u
+}
+
+// UpdateKiroCreditTargetUsd sets the "kiro_credit_target_usd" field to the value that was provided on create.
+func (u *GroupUpsert) UpdateKiroCreditTargetUsd() *GroupUpsert {
+	u.SetExcluded(group.FieldKiroCreditTargetUsd)
+	return u
+}
+
+// AddKiroCreditTargetUsd adds v to the "kiro_credit_target_usd" field.
+func (u *GroupUpsert) AddKiroCreditTargetUsd(v float64) *GroupUpsert {
+	u.Add(group.FieldKiroCreditTargetUsd, v)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create.
 // Using this option is equivalent to using:
 //
@@ -2613,6 +2656,27 @@ func (u *GroupUpsertOne) AddKiroCacheEmulationRatio(v float64) *GroupUpsertOne {
 func (u *GroupUpsertOne) UpdateKiroCacheEmulationRatio() *GroupUpsertOne {
 	return u.Update(func(s *GroupUpsert) {
 		s.UpdateKiroCacheEmulationRatio()
+	})
+}
+
+// SetKiroCreditTargetUsd sets the "kiro_credit_target_usd" field.
+func (u *GroupUpsertOne) SetKiroCreditTargetUsd(v float64) *GroupUpsertOne {
+	return u.Update(func(s *GroupUpsert) {
+		s.SetKiroCreditTargetUsd(v)
+	})
+}
+
+// AddKiroCreditTargetUsd adds v to the "kiro_credit_target_usd" field.
+func (u *GroupUpsertOne) AddKiroCreditTargetUsd(v float64) *GroupUpsertOne {
+	return u.Update(func(s *GroupUpsert) {
+		s.AddKiroCreditTargetUsd(v)
+	})
+}
+
+// UpdateKiroCreditTargetUsd sets the "kiro_credit_target_usd" field to the value that was provided on create.
+func (u *GroupUpsertOne) UpdateKiroCreditTargetUsd() *GroupUpsertOne {
+	return u.Update(func(s *GroupUpsert) {
+		s.UpdateKiroCreditTargetUsd()
 	})
 }
 
@@ -3538,6 +3602,27 @@ func (u *GroupUpsertBulk) AddKiroCacheEmulationRatio(v float64) *GroupUpsertBulk
 func (u *GroupUpsertBulk) UpdateKiroCacheEmulationRatio() *GroupUpsertBulk {
 	return u.Update(func(s *GroupUpsert) {
 		s.UpdateKiroCacheEmulationRatio()
+	})
+}
+
+// SetKiroCreditTargetUsd sets the "kiro_credit_target_usd" field.
+func (u *GroupUpsertBulk) SetKiroCreditTargetUsd(v float64) *GroupUpsertBulk {
+	return u.Update(func(s *GroupUpsert) {
+		s.SetKiroCreditTargetUsd(v)
+	})
+}
+
+// AddKiroCreditTargetUsd adds v to the "kiro_credit_target_usd" field.
+func (u *GroupUpsertBulk) AddKiroCreditTargetUsd(v float64) *GroupUpsertBulk {
+	return u.Update(func(s *GroupUpsert) {
+		s.AddKiroCreditTargetUsd(v)
+	})
+}
+
+// UpdateKiroCreditTargetUsd sets the "kiro_credit_target_usd" field to the value that was provided on create.
+func (u *GroupUpsertBulk) UpdateKiroCreditTargetUsd() *GroupUpsertBulk {
+	return u.Update(func(s *GroupUpsert) {
+		s.UpdateKiroCreditTargetUsd()
 	})
 }
 

--- a/backend/ent/group_update.go
+++ b/backend/ent/group_update.go
@@ -721,6 +721,27 @@ func (_u *GroupUpdate) AddKiroCacheEmulationRatio(v float64) *GroupUpdate {
 	return _u
 }
 
+// SetKiroCreditTargetUsd sets the "kiro_credit_target_usd" field.
+func (_u *GroupUpdate) SetKiroCreditTargetUsd(v float64) *GroupUpdate {
+	_u.mutation.ResetKiroCreditTargetUsd()
+	_u.mutation.SetKiroCreditTargetUsd(v)
+	return _u
+}
+
+// SetNillableKiroCreditTargetUsd sets the "kiro_credit_target_usd" field if the given value is not nil.
+func (_u *GroupUpdate) SetNillableKiroCreditTargetUsd(v *float64) *GroupUpdate {
+	if v != nil {
+		_u.SetKiroCreditTargetUsd(*v)
+	}
+	return _u
+}
+
+// AddKiroCreditTargetUsd adds value to the "kiro_credit_target_usd" field.
+func (_u *GroupUpdate) AddKiroCreditTargetUsd(v float64) *GroupUpdate {
+	_u.mutation.AddKiroCreditTargetUsd(v)
+	return _u
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by IDs.
 func (_u *GroupUpdate) AddAPIKeyIDs(ids ...int64) *GroupUpdate {
 	_u.mutation.AddAPIKeyIDs(ids...)
@@ -1222,6 +1243,12 @@ func (_u *GroupUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.AddedKiroCacheEmulationRatio(); ok {
 		_spec.AddField(group.FieldKiroCacheEmulationRatio, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.KiroCreditTargetUsd(); ok {
+		_spec.SetField(group.FieldKiroCreditTargetUsd, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.AddedKiroCreditTargetUsd(); ok {
+		_spec.AddField(group.FieldKiroCreditTargetUsd, field.TypeFloat64, value)
 	}
 	if _u.mutation.APIKeysCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -2222,6 +2249,27 @@ func (_u *GroupUpdateOne) AddKiroCacheEmulationRatio(v float64) *GroupUpdateOne 
 	return _u
 }
 
+// SetKiroCreditTargetUsd sets the "kiro_credit_target_usd" field.
+func (_u *GroupUpdateOne) SetKiroCreditTargetUsd(v float64) *GroupUpdateOne {
+	_u.mutation.ResetKiroCreditTargetUsd()
+	_u.mutation.SetKiroCreditTargetUsd(v)
+	return _u
+}
+
+// SetNillableKiroCreditTargetUsd sets the "kiro_credit_target_usd" field if the given value is not nil.
+func (_u *GroupUpdateOne) SetNillableKiroCreditTargetUsd(v *float64) *GroupUpdateOne {
+	if v != nil {
+		_u.SetKiroCreditTargetUsd(*v)
+	}
+	return _u
+}
+
+// AddKiroCreditTargetUsd adds value to the "kiro_credit_target_usd" field.
+func (_u *GroupUpdateOne) AddKiroCreditTargetUsd(v float64) *GroupUpdateOne {
+	_u.mutation.AddKiroCreditTargetUsd(v)
+	return _u
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by IDs.
 func (_u *GroupUpdateOne) AddAPIKeyIDs(ids ...int64) *GroupUpdateOne {
 	_u.mutation.AddAPIKeyIDs(ids...)
@@ -2753,6 +2801,12 @@ func (_u *GroupUpdateOne) sqlSave(ctx context.Context) (_node *Group, err error)
 	}
 	if value, ok := _u.mutation.AddedKiroCacheEmulationRatio(); ok {
 		_spec.AddField(group.FieldKiroCacheEmulationRatio, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.KiroCreditTargetUsd(); ok {
+		_spec.SetField(group.FieldKiroCreditTargetUsd, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.AddedKiroCreditTargetUsd(); ok {
+		_spec.AddField(group.FieldKiroCreditTargetUsd, field.TypeFloat64, value)
 	}
 	if _u.mutation.APIKeysCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/backend/ent/group_update.go
+++ b/backend/ent/group_update.go
@@ -742,6 +742,27 @@ func (_u *GroupUpdate) AddKiroCreditTargetUsd(v float64) *GroupUpdate {
 	return _u
 }
 
+// SetKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field.
+func (_u *GroupUpdate) SetKiroCacheForceRatioCenter(v float64) *GroupUpdate {
+	_u.mutation.ResetKiroCacheForceRatioCenter()
+	_u.mutation.SetKiroCacheForceRatioCenter(v)
+	return _u
+}
+
+// SetNillableKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field if the given value is not nil.
+func (_u *GroupUpdate) SetNillableKiroCacheForceRatioCenter(v *float64) *GroupUpdate {
+	if v != nil {
+		_u.SetKiroCacheForceRatioCenter(*v)
+	}
+	return _u
+}
+
+// AddKiroCacheForceRatioCenter adds value to the "kiro_cache_force_ratio_center" field.
+func (_u *GroupUpdate) AddKiroCacheForceRatioCenter(v float64) *GroupUpdate {
+	_u.mutation.AddKiroCacheForceRatioCenter(v)
+	return _u
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by IDs.
 func (_u *GroupUpdate) AddAPIKeyIDs(ids ...int64) *GroupUpdate {
 	_u.mutation.AddAPIKeyIDs(ids...)
@@ -1249,6 +1270,12 @@ func (_u *GroupUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.AddedKiroCreditTargetUsd(); ok {
 		_spec.AddField(group.FieldKiroCreditTargetUsd, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.KiroCacheForceRatioCenter(); ok {
+		_spec.SetField(group.FieldKiroCacheForceRatioCenter, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.AddedKiroCacheForceRatioCenter(); ok {
+		_spec.AddField(group.FieldKiroCacheForceRatioCenter, field.TypeFloat64, value)
 	}
 	if _u.mutation.APIKeysCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -2270,6 +2297,27 @@ func (_u *GroupUpdateOne) AddKiroCreditTargetUsd(v float64) *GroupUpdateOne {
 	return _u
 }
 
+// SetKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field.
+func (_u *GroupUpdateOne) SetKiroCacheForceRatioCenter(v float64) *GroupUpdateOne {
+	_u.mutation.ResetKiroCacheForceRatioCenter()
+	_u.mutation.SetKiroCacheForceRatioCenter(v)
+	return _u
+}
+
+// SetNillableKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field if the given value is not nil.
+func (_u *GroupUpdateOne) SetNillableKiroCacheForceRatioCenter(v *float64) *GroupUpdateOne {
+	if v != nil {
+		_u.SetKiroCacheForceRatioCenter(*v)
+	}
+	return _u
+}
+
+// AddKiroCacheForceRatioCenter adds value to the "kiro_cache_force_ratio_center" field.
+func (_u *GroupUpdateOne) AddKiroCacheForceRatioCenter(v float64) *GroupUpdateOne {
+	_u.mutation.AddKiroCacheForceRatioCenter(v)
+	return _u
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by IDs.
 func (_u *GroupUpdateOne) AddAPIKeyIDs(ids ...int64) *GroupUpdateOne {
 	_u.mutation.AddAPIKeyIDs(ids...)
@@ -2807,6 +2855,12 @@ func (_u *GroupUpdateOne) sqlSave(ctx context.Context) (_node *Group, err error)
 	}
 	if value, ok := _u.mutation.AddedKiroCreditTargetUsd(); ok {
 		_spec.AddField(group.FieldKiroCreditTargetUsd, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.KiroCacheForceRatioCenter(); ok {
+		_spec.SetField(group.FieldKiroCacheForceRatioCenter, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.AddedKiroCacheForceRatioCenter(); ok {
+		_spec.AddField(group.FieldKiroCacheForceRatioCenter, field.TypeFloat64, value)
 	}
 	if _u.mutation.APIKeysCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -676,6 +676,7 @@ var (
 		{Name: "kiro_auto_sticky_enabled", Type: field.TypeBool, Default: true},
 		{Name: "kiro_sticky_session_ttl_seconds", Type: field.TypeInt, Default: 3600},
 		{Name: "kiro_cache_emulation_ratio", Type: field.TypeFloat64, Default: 1, SchemaType: map[string]string{"postgres": "decimal(5,4)"}},
+		{Name: "kiro_credit_target_usd", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "decimal(8,4)"}},
 	}
 	// GroupsTable holds the schema information for the "groups" table.
 	GroupsTable = &schema.Table{
@@ -1348,6 +1349,7 @@ var (
 		{Name: "cache_read_tokens", Type: field.TypeInt, Default: 0},
 		{Name: "cache_creation_5m_tokens", Type: field.TypeInt, Default: 0},
 		{Name: "cache_creation_1h_tokens", Type: field.TypeInt, Default: 0},
+		{Name: "kiro_credits", Type: field.TypeFloat64, Nullable: true, SchemaType: map[string]string{"postgres": "decimal(10,4)"}},
 		{Name: "input_cost", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "decimal(20,10)"}},
 		{Name: "output_cost", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "decimal(20,10)"}},
 		{Name: "cache_creation_cost", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "decimal(20,10)"}},
@@ -1384,31 +1386,31 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "usage_logs_api_keys_usage_logs",
-				Columns:    []*schema.Column{UsageLogsColumns[37]},
+				Columns:    []*schema.Column{UsageLogsColumns[38]},
 				RefColumns: []*schema.Column{APIKeysColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "usage_logs_accounts_usage_logs",
-				Columns:    []*schema.Column{UsageLogsColumns[38]},
+				Columns:    []*schema.Column{UsageLogsColumns[39]},
 				RefColumns: []*schema.Column{AccountsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "usage_logs_groups_usage_logs",
-				Columns:    []*schema.Column{UsageLogsColumns[39]},
+				Columns:    []*schema.Column{UsageLogsColumns[40]},
 				RefColumns: []*schema.Column{GroupsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "usage_logs_users_usage_logs",
-				Columns:    []*schema.Column{UsageLogsColumns[40]},
+				Columns:    []*schema.Column{UsageLogsColumns[41]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "usage_logs_user_subscriptions_usage_logs",
-				Columns:    []*schema.Column{UsageLogsColumns[41]},
+				Columns:    []*schema.Column{UsageLogsColumns[42]},
 				RefColumns: []*schema.Column{UserSubscriptionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -1417,32 +1419,32 @@ var (
 			{
 				Name:    "usagelog_user_id",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[40]},
+				Columns: []*schema.Column{UsageLogsColumns[41]},
 			},
 			{
 				Name:    "usagelog_api_key_id",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[37]},
+				Columns: []*schema.Column{UsageLogsColumns[38]},
 			},
 			{
 				Name:    "usagelog_account_id",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[38]},
+				Columns: []*schema.Column{UsageLogsColumns[39]},
 			},
 			{
 				Name:    "usagelog_group_id",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[39]},
+				Columns: []*schema.Column{UsageLogsColumns[40]},
 			},
 			{
 				Name:    "usagelog_subscription_id",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[41]},
+				Columns: []*schema.Column{UsageLogsColumns[42]},
 			},
 			{
 				Name:    "usagelog_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[36]},
+				Columns: []*schema.Column{UsageLogsColumns[37]},
 			},
 			{
 				Name:    "usagelog_model",
@@ -1462,17 +1464,17 @@ var (
 			{
 				Name:    "usagelog_user_id_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[40], UsageLogsColumns[36]},
+				Columns: []*schema.Column{UsageLogsColumns[41], UsageLogsColumns[37]},
 			},
 			{
 				Name:    "usagelog_api_key_id_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[37], UsageLogsColumns[36]},
+				Columns: []*schema.Column{UsageLogsColumns[38], UsageLogsColumns[37]},
 			},
 			{
 				Name:    "usagelog_group_id_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{UsageLogsColumns[39], UsageLogsColumns[36]},
+				Columns: []*schema.Column{UsageLogsColumns[40], UsageLogsColumns[37]},
 			},
 		},
 	}

--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -677,6 +677,7 @@ var (
 		{Name: "kiro_sticky_session_ttl_seconds", Type: field.TypeInt, Default: 3600},
 		{Name: "kiro_cache_emulation_ratio", Type: field.TypeFloat64, Default: 1, SchemaType: map[string]string{"postgres": "decimal(5,4)"}},
 		{Name: "kiro_credit_target_usd", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "decimal(8,4)"}},
+		{Name: "kiro_cache_force_ratio_center", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "decimal(5,4)"}},
 	}
 	// GroupsTable holds the schema information for the "groups" table.
 	GroupsTable = &schema.Table{

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -15017,6 +15017,8 @@ type GroupMutation struct {
 	addkiro_sticky_session_ttl_seconds      *int
 	kiro_cache_emulation_ratio              *float64
 	addkiro_cache_emulation_ratio           *float64
+	kiro_credit_target_usd                  *float64
+	addkiro_credit_target_usd               *float64
 	clearedFields                           map[string]struct{}
 	api_keys                                map[int64]struct{}
 	removedapi_keys                         map[int64]struct{}
@@ -17009,6 +17011,62 @@ func (m *GroupMutation) ResetKiroCacheEmulationRatio() {
 	m.addkiro_cache_emulation_ratio = nil
 }
 
+// SetKiroCreditTargetUsd sets the "kiro_credit_target_usd" field.
+func (m *GroupMutation) SetKiroCreditTargetUsd(f float64) {
+	m.kiro_credit_target_usd = &f
+	m.addkiro_credit_target_usd = nil
+}
+
+// KiroCreditTargetUsd returns the value of the "kiro_credit_target_usd" field in the mutation.
+func (m *GroupMutation) KiroCreditTargetUsd() (r float64, exists bool) {
+	v := m.kiro_credit_target_usd
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldKiroCreditTargetUsd returns the old "kiro_credit_target_usd" field's value of the Group entity.
+// If the Group object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *GroupMutation) OldKiroCreditTargetUsd(ctx context.Context) (v float64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldKiroCreditTargetUsd is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldKiroCreditTargetUsd requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldKiroCreditTargetUsd: %w", err)
+	}
+	return oldValue.KiroCreditTargetUsd, nil
+}
+
+// AddKiroCreditTargetUsd adds f to the "kiro_credit_target_usd" field.
+func (m *GroupMutation) AddKiroCreditTargetUsd(f float64) {
+	if m.addkiro_credit_target_usd != nil {
+		*m.addkiro_credit_target_usd += f
+	} else {
+		m.addkiro_credit_target_usd = &f
+	}
+}
+
+// AddedKiroCreditTargetUsd returns the value that was added to the "kiro_credit_target_usd" field in this mutation.
+func (m *GroupMutation) AddedKiroCreditTargetUsd() (r float64, exists bool) {
+	v := m.addkiro_credit_target_usd
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetKiroCreditTargetUsd resets all changes to the "kiro_credit_target_usd" field.
+func (m *GroupMutation) ResetKiroCreditTargetUsd() {
+	m.kiro_credit_target_usd = nil
+	m.addkiro_credit_target_usd = nil
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by ids.
 func (m *GroupMutation) AddAPIKeyIDs(ids ...int64) {
 	if m.api_keys == nil {
@@ -17367,7 +17425,7 @@ func (m *GroupMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *GroupMutation) Fields() []string {
-	fields := make([]string, 0, 39)
+	fields := make([]string, 0, 40)
 	if m.created_at != nil {
 		fields = append(fields, group.FieldCreatedAt)
 	}
@@ -17485,6 +17543,9 @@ func (m *GroupMutation) Fields() []string {
 	if m.kiro_cache_emulation_ratio != nil {
 		fields = append(fields, group.FieldKiroCacheEmulationRatio)
 	}
+	if m.kiro_credit_target_usd != nil {
+		fields = append(fields, group.FieldKiroCreditTargetUsd)
+	}
 	return fields
 }
 
@@ -17571,6 +17632,8 @@ func (m *GroupMutation) Field(name string) (ent.Value, bool) {
 		return m.KiroStickySessionTTLSeconds()
 	case group.FieldKiroCacheEmulationRatio:
 		return m.KiroCacheEmulationRatio()
+	case group.FieldKiroCreditTargetUsd:
+		return m.KiroCreditTargetUsd()
 	}
 	return nil, false
 }
@@ -17658,6 +17721,8 @@ func (m *GroupMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldKiroStickySessionTTLSeconds(ctx)
 	case group.FieldKiroCacheEmulationRatio:
 		return m.OldKiroCacheEmulationRatio(ctx)
+	case group.FieldKiroCreditTargetUsd:
+		return m.OldKiroCreditTargetUsd(ctx)
 	}
 	return nil, fmt.Errorf("unknown Group field %s", name)
 }
@@ -17940,6 +18005,13 @@ func (m *GroupMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetKiroCacheEmulationRatio(v)
 		return nil
+	case group.FieldKiroCreditTargetUsd:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetKiroCreditTargetUsd(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Group field %s", name)
 }
@@ -17993,6 +18065,9 @@ func (m *GroupMutation) AddedFields() []string {
 	if m.addkiro_cache_emulation_ratio != nil {
 		fields = append(fields, group.FieldKiroCacheEmulationRatio)
 	}
+	if m.addkiro_credit_target_usd != nil {
+		fields = append(fields, group.FieldKiroCreditTargetUsd)
+	}
 	return fields
 }
 
@@ -18031,6 +18106,8 @@ func (m *GroupMutation) AddedField(name string) (ent.Value, bool) {
 		return m.AddedKiroStickySessionTTLSeconds()
 	case group.FieldKiroCacheEmulationRatio:
 		return m.AddedKiroCacheEmulationRatio()
+	case group.FieldKiroCreditTargetUsd:
+		return m.AddedKiroCreditTargetUsd()
 	}
 	return nil, false
 }
@@ -18144,6 +18221,13 @@ func (m *GroupMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddKiroCacheEmulationRatio(v)
+		return nil
+	case group.FieldKiroCreditTargetUsd:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddKiroCreditTargetUsd(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Group numeric field %s", name)
@@ -18357,6 +18441,9 @@ func (m *GroupMutation) ResetField(name string) error {
 		return nil
 	case group.FieldKiroCacheEmulationRatio:
 		m.ResetKiroCacheEmulationRatio()
+		return nil
+	case group.FieldKiroCreditTargetUsd:
+		m.ResetKiroCreditTargetUsd()
 		return nil
 	}
 	return fmt.Errorf("unknown Group field %s", name)
@@ -35191,6 +35278,8 @@ type UsageLogMutation struct {
 	addcache_creation_5m_tokens *int
 	cache_creation_1h_tokens    *int
 	addcache_creation_1h_tokens *int
+	kiro_credits                *float64
+	addkiro_credits             *float64
 	input_cost                  *float64
 	addinput_cost               *float64
 	output_cost                 *float64
@@ -36266,6 +36355,76 @@ func (m *UsageLogMutation) AddedCacheCreation1hTokens() (r int, exists bool) {
 func (m *UsageLogMutation) ResetCacheCreation1hTokens() {
 	m.cache_creation_1h_tokens = nil
 	m.addcache_creation_1h_tokens = nil
+}
+
+// SetKiroCredits sets the "kiro_credits" field.
+func (m *UsageLogMutation) SetKiroCredits(f float64) {
+	m.kiro_credits = &f
+	m.addkiro_credits = nil
+}
+
+// KiroCredits returns the value of the "kiro_credits" field in the mutation.
+func (m *UsageLogMutation) KiroCredits() (r float64, exists bool) {
+	v := m.kiro_credits
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldKiroCredits returns the old "kiro_credits" field's value of the UsageLog entity.
+// If the UsageLog object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UsageLogMutation) OldKiroCredits(ctx context.Context) (v *float64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldKiroCredits is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldKiroCredits requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldKiroCredits: %w", err)
+	}
+	return oldValue.KiroCredits, nil
+}
+
+// AddKiroCredits adds f to the "kiro_credits" field.
+func (m *UsageLogMutation) AddKiroCredits(f float64) {
+	if m.addkiro_credits != nil {
+		*m.addkiro_credits += f
+	} else {
+		m.addkiro_credits = &f
+	}
+}
+
+// AddedKiroCredits returns the value that was added to the "kiro_credits" field in this mutation.
+func (m *UsageLogMutation) AddedKiroCredits() (r float64, exists bool) {
+	v := m.addkiro_credits
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearKiroCredits clears the value of the "kiro_credits" field.
+func (m *UsageLogMutation) ClearKiroCredits() {
+	m.kiro_credits = nil
+	m.addkiro_credits = nil
+	m.clearedFields[usagelog.FieldKiroCredits] = struct{}{}
+}
+
+// KiroCreditsCleared returns if the "kiro_credits" field was cleared in this mutation.
+func (m *UsageLogMutation) KiroCreditsCleared() bool {
+	_, ok := m.clearedFields[usagelog.FieldKiroCredits]
+	return ok
+}
+
+// ResetKiroCredits resets all changes to the "kiro_credits" field.
+func (m *UsageLogMutation) ResetKiroCredits() {
+	m.kiro_credits = nil
+	m.addkiro_credits = nil
+	delete(m.clearedFields, usagelog.FieldKiroCredits)
 }
 
 // SetInputCost sets the "input_cost" field.
@@ -37602,7 +37761,7 @@ func (m *UsageLogMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UsageLogMutation) Fields() []string {
-	fields := make([]string, 0, 41)
+	fields := make([]string, 0, 42)
 	if m.user != nil {
 		fields = append(fields, usagelog.FieldUserID)
 	}
@@ -37659,6 +37818,9 @@ func (m *UsageLogMutation) Fields() []string {
 	}
 	if m.cache_creation_1h_tokens != nil {
 		fields = append(fields, usagelog.FieldCacheCreation1hTokens)
+	}
+	if m.kiro_credits != nil {
+		fields = append(fields, usagelog.FieldKiroCredits)
 	}
 	if m.input_cost != nil {
 		fields = append(fields, usagelog.FieldInputCost)
@@ -37772,6 +37934,8 @@ func (m *UsageLogMutation) Field(name string) (ent.Value, bool) {
 		return m.CacheCreation5mTokens()
 	case usagelog.FieldCacheCreation1hTokens:
 		return m.CacheCreation1hTokens()
+	case usagelog.FieldKiroCredits:
+		return m.KiroCredits()
 	case usagelog.FieldInputCost:
 		return m.InputCost()
 	case usagelog.FieldOutputCost:
@@ -37863,6 +38027,8 @@ func (m *UsageLogMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldCacheCreation5mTokens(ctx)
 	case usagelog.FieldCacheCreation1hTokens:
 		return m.OldCacheCreation1hTokens(ctx)
+	case usagelog.FieldKiroCredits:
+		return m.OldKiroCredits(ctx)
 	case usagelog.FieldInputCost:
 		return m.OldInputCost(ctx)
 	case usagelog.FieldOutputCost:
@@ -38049,6 +38215,13 @@ func (m *UsageLogMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetCacheCreation1hTokens(v)
 		return nil
+	case usagelog.FieldKiroCredits:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetKiroCredits(v)
+		return nil
 	case usagelog.FieldInputCost:
 		v, ok := value.(float64)
 		if !ok {
@@ -38232,6 +38405,9 @@ func (m *UsageLogMutation) AddedFields() []string {
 	if m.addcache_creation_1h_tokens != nil {
 		fields = append(fields, usagelog.FieldCacheCreation1hTokens)
 	}
+	if m.addkiro_credits != nil {
+		fields = append(fields, usagelog.FieldKiroCredits)
+	}
 	if m.addinput_cost != nil {
 		fields = append(fields, usagelog.FieldInputCost)
 	}
@@ -38290,6 +38466,8 @@ func (m *UsageLogMutation) AddedField(name string) (ent.Value, bool) {
 		return m.AddedCacheCreation5mTokens()
 	case usagelog.FieldCacheCreation1hTokens:
 		return m.AddedCacheCreation1hTokens()
+	case usagelog.FieldKiroCredits:
+		return m.AddedKiroCredits()
 	case usagelog.FieldInputCost:
 		return m.AddedInputCost()
 	case usagelog.FieldOutputCost:
@@ -38371,6 +38549,13 @@ func (m *UsageLogMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddCacheCreation1hTokens(v)
+		return nil
+	case usagelog.FieldKiroCredits:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddKiroCredits(v)
 		return nil
 	case usagelog.FieldInputCost:
 		v, ok := value.(float64)
@@ -38488,6 +38673,9 @@ func (m *UsageLogMutation) ClearedFields() []string {
 	if m.FieldCleared(usagelog.FieldSubscriptionID) {
 		fields = append(fields, usagelog.FieldSubscriptionID)
 	}
+	if m.FieldCleared(usagelog.FieldKiroCredits) {
+		fields = append(fields, usagelog.FieldKiroCredits)
+	}
 	if m.FieldCleared(usagelog.FieldAccountRateMultiplier) {
 		fields = append(fields, usagelog.FieldAccountRateMultiplier)
 	}
@@ -38555,6 +38743,9 @@ func (m *UsageLogMutation) ClearField(name string) error {
 		return nil
 	case usagelog.FieldSubscriptionID:
 		m.ClearSubscriptionID()
+		return nil
+	case usagelog.FieldKiroCredits:
+		m.ClearKiroCredits()
 		return nil
 	case usagelog.FieldAccountRateMultiplier:
 		m.ClearAccountRateMultiplier()
@@ -38650,6 +38841,9 @@ func (m *UsageLogMutation) ResetField(name string) error {
 		return nil
 	case usagelog.FieldCacheCreation1hTokens:
 		m.ResetCacheCreation1hTokens()
+		return nil
+	case usagelog.FieldKiroCredits:
+		m.ResetKiroCredits()
 		return nil
 	case usagelog.FieldInputCost:
 		m.ResetInputCost()

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -15019,6 +15019,8 @@ type GroupMutation struct {
 	addkiro_cache_emulation_ratio           *float64
 	kiro_credit_target_usd                  *float64
 	addkiro_credit_target_usd               *float64
+	kiro_cache_force_ratio_center           *float64
+	addkiro_cache_force_ratio_center        *float64
 	clearedFields                           map[string]struct{}
 	api_keys                                map[int64]struct{}
 	removedapi_keys                         map[int64]struct{}
@@ -17067,6 +17069,62 @@ func (m *GroupMutation) ResetKiroCreditTargetUsd() {
 	m.addkiro_credit_target_usd = nil
 }
 
+// SetKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field.
+func (m *GroupMutation) SetKiroCacheForceRatioCenter(f float64) {
+	m.kiro_cache_force_ratio_center = &f
+	m.addkiro_cache_force_ratio_center = nil
+}
+
+// KiroCacheForceRatioCenter returns the value of the "kiro_cache_force_ratio_center" field in the mutation.
+func (m *GroupMutation) KiroCacheForceRatioCenter() (r float64, exists bool) {
+	v := m.kiro_cache_force_ratio_center
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldKiroCacheForceRatioCenter returns the old "kiro_cache_force_ratio_center" field's value of the Group entity.
+// If the Group object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *GroupMutation) OldKiroCacheForceRatioCenter(ctx context.Context) (v float64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldKiroCacheForceRatioCenter is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldKiroCacheForceRatioCenter requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldKiroCacheForceRatioCenter: %w", err)
+	}
+	return oldValue.KiroCacheForceRatioCenter, nil
+}
+
+// AddKiroCacheForceRatioCenter adds f to the "kiro_cache_force_ratio_center" field.
+func (m *GroupMutation) AddKiroCacheForceRatioCenter(f float64) {
+	if m.addkiro_cache_force_ratio_center != nil {
+		*m.addkiro_cache_force_ratio_center += f
+	} else {
+		m.addkiro_cache_force_ratio_center = &f
+	}
+}
+
+// AddedKiroCacheForceRatioCenter returns the value that was added to the "kiro_cache_force_ratio_center" field in this mutation.
+func (m *GroupMutation) AddedKiroCacheForceRatioCenter() (r float64, exists bool) {
+	v := m.addkiro_cache_force_ratio_center
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetKiroCacheForceRatioCenter resets all changes to the "kiro_cache_force_ratio_center" field.
+func (m *GroupMutation) ResetKiroCacheForceRatioCenter() {
+	m.kiro_cache_force_ratio_center = nil
+	m.addkiro_cache_force_ratio_center = nil
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by ids.
 func (m *GroupMutation) AddAPIKeyIDs(ids ...int64) {
 	if m.api_keys == nil {
@@ -17425,7 +17483,7 @@ func (m *GroupMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *GroupMutation) Fields() []string {
-	fields := make([]string, 0, 40)
+	fields := make([]string, 0, 41)
 	if m.created_at != nil {
 		fields = append(fields, group.FieldCreatedAt)
 	}
@@ -17546,6 +17604,9 @@ func (m *GroupMutation) Fields() []string {
 	if m.kiro_credit_target_usd != nil {
 		fields = append(fields, group.FieldKiroCreditTargetUsd)
 	}
+	if m.kiro_cache_force_ratio_center != nil {
+		fields = append(fields, group.FieldKiroCacheForceRatioCenter)
+	}
 	return fields
 }
 
@@ -17634,6 +17695,8 @@ func (m *GroupMutation) Field(name string) (ent.Value, bool) {
 		return m.KiroCacheEmulationRatio()
 	case group.FieldKiroCreditTargetUsd:
 		return m.KiroCreditTargetUsd()
+	case group.FieldKiroCacheForceRatioCenter:
+		return m.KiroCacheForceRatioCenter()
 	}
 	return nil, false
 }
@@ -17723,6 +17786,8 @@ func (m *GroupMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldKiroCacheEmulationRatio(ctx)
 	case group.FieldKiroCreditTargetUsd:
 		return m.OldKiroCreditTargetUsd(ctx)
+	case group.FieldKiroCacheForceRatioCenter:
+		return m.OldKiroCacheForceRatioCenter(ctx)
 	}
 	return nil, fmt.Errorf("unknown Group field %s", name)
 }
@@ -18012,6 +18077,13 @@ func (m *GroupMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetKiroCreditTargetUsd(v)
 		return nil
+	case group.FieldKiroCacheForceRatioCenter:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetKiroCacheForceRatioCenter(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Group field %s", name)
 }
@@ -18068,6 +18140,9 @@ func (m *GroupMutation) AddedFields() []string {
 	if m.addkiro_credit_target_usd != nil {
 		fields = append(fields, group.FieldKiroCreditTargetUsd)
 	}
+	if m.addkiro_cache_force_ratio_center != nil {
+		fields = append(fields, group.FieldKiroCacheForceRatioCenter)
+	}
 	return fields
 }
 
@@ -18108,6 +18183,8 @@ func (m *GroupMutation) AddedField(name string) (ent.Value, bool) {
 		return m.AddedKiroCacheEmulationRatio()
 	case group.FieldKiroCreditTargetUsd:
 		return m.AddedKiroCreditTargetUsd()
+	case group.FieldKiroCacheForceRatioCenter:
+		return m.AddedKiroCacheForceRatioCenter()
 	}
 	return nil, false
 }
@@ -18228,6 +18305,13 @@ func (m *GroupMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddKiroCreditTargetUsd(v)
+		return nil
+	case group.FieldKiroCacheForceRatioCenter:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddKiroCacheForceRatioCenter(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Group numeric field %s", name)
@@ -18444,6 +18528,9 @@ func (m *GroupMutation) ResetField(name string) error {
 		return nil
 	case group.FieldKiroCreditTargetUsd:
 		m.ResetKiroCreditTargetUsd()
+		return nil
+	case group.FieldKiroCacheForceRatioCenter:
+		m.ResetKiroCacheForceRatioCenter()
 		return nil
 	}
 	return fmt.Errorf("unknown Group field %s", name)

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -894,6 +894,10 @@ func init() {
 	groupDescKiroCacheEmulationRatio := groupFields[35].Descriptor()
 	// group.DefaultKiroCacheEmulationRatio holds the default value on creation for the kiro_cache_emulation_ratio field.
 	group.DefaultKiroCacheEmulationRatio = groupDescKiroCacheEmulationRatio.Default.(float64)
+	// groupDescKiroCreditTargetUsd is the schema descriptor for kiro_credit_target_usd field.
+	groupDescKiroCreditTargetUsd := groupFields[36].Descriptor()
+	// group.DefaultKiroCreditTargetUsd holds the default value on creation for the kiro_credit_target_usd field.
+	group.DefaultKiroCreditTargetUsd = groupDescKiroCreditTargetUsd.Default.(float64)
 	idempotencyrecordMixin := schema.IdempotencyRecord{}.Mixin()
 	idempotencyrecordMixinFields0 := idempotencyrecordMixin[0].Fields()
 	_ = idempotencyrecordMixinFields0
@@ -1714,75 +1718,75 @@ func init() {
 	// usagelog.DefaultCacheCreation1hTokens holds the default value on creation for the cache_creation_1h_tokens field.
 	usagelog.DefaultCacheCreation1hTokens = usagelogDescCacheCreation1hTokens.Default.(int)
 	// usagelogDescInputCost is the schema descriptor for input_cost field.
-	usagelogDescInputCost := usagelogFields[19].Descriptor()
+	usagelogDescInputCost := usagelogFields[20].Descriptor()
 	// usagelog.DefaultInputCost holds the default value on creation for the input_cost field.
 	usagelog.DefaultInputCost = usagelogDescInputCost.Default.(float64)
 	// usagelogDescOutputCost is the schema descriptor for output_cost field.
-	usagelogDescOutputCost := usagelogFields[20].Descriptor()
+	usagelogDescOutputCost := usagelogFields[21].Descriptor()
 	// usagelog.DefaultOutputCost holds the default value on creation for the output_cost field.
 	usagelog.DefaultOutputCost = usagelogDescOutputCost.Default.(float64)
 	// usagelogDescCacheCreationCost is the schema descriptor for cache_creation_cost field.
-	usagelogDescCacheCreationCost := usagelogFields[21].Descriptor()
+	usagelogDescCacheCreationCost := usagelogFields[22].Descriptor()
 	// usagelog.DefaultCacheCreationCost holds the default value on creation for the cache_creation_cost field.
 	usagelog.DefaultCacheCreationCost = usagelogDescCacheCreationCost.Default.(float64)
 	// usagelogDescCacheReadCost is the schema descriptor for cache_read_cost field.
-	usagelogDescCacheReadCost := usagelogFields[22].Descriptor()
+	usagelogDescCacheReadCost := usagelogFields[23].Descriptor()
 	// usagelog.DefaultCacheReadCost holds the default value on creation for the cache_read_cost field.
 	usagelog.DefaultCacheReadCost = usagelogDescCacheReadCost.Default.(float64)
 	// usagelogDescTotalCost is the schema descriptor for total_cost field.
-	usagelogDescTotalCost := usagelogFields[23].Descriptor()
+	usagelogDescTotalCost := usagelogFields[24].Descriptor()
 	// usagelog.DefaultTotalCost holds the default value on creation for the total_cost field.
 	usagelog.DefaultTotalCost = usagelogDescTotalCost.Default.(float64)
 	// usagelogDescActualCost is the schema descriptor for actual_cost field.
-	usagelogDescActualCost := usagelogFields[24].Descriptor()
+	usagelogDescActualCost := usagelogFields[25].Descriptor()
 	// usagelog.DefaultActualCost holds the default value on creation for the actual_cost field.
 	usagelog.DefaultActualCost = usagelogDescActualCost.Default.(float64)
 	// usagelogDescRateMultiplier is the schema descriptor for rate_multiplier field.
-	usagelogDescRateMultiplier := usagelogFields[25].Descriptor()
+	usagelogDescRateMultiplier := usagelogFields[26].Descriptor()
 	// usagelog.DefaultRateMultiplier holds the default value on creation for the rate_multiplier field.
 	usagelog.DefaultRateMultiplier = usagelogDescRateMultiplier.Default.(float64)
 	// usagelogDescBillingType is the schema descriptor for billing_type field.
-	usagelogDescBillingType := usagelogFields[27].Descriptor()
+	usagelogDescBillingType := usagelogFields[28].Descriptor()
 	// usagelog.DefaultBillingType holds the default value on creation for the billing_type field.
 	usagelog.DefaultBillingType = usagelogDescBillingType.Default.(int8)
 	// usagelogDescStream is the schema descriptor for stream field.
-	usagelogDescStream := usagelogFields[28].Descriptor()
+	usagelogDescStream := usagelogFields[29].Descriptor()
 	// usagelog.DefaultStream holds the default value on creation for the stream field.
 	usagelog.DefaultStream = usagelogDescStream.Default.(bool)
 	// usagelogDescUserAgent is the schema descriptor for user_agent field.
-	usagelogDescUserAgent := usagelogFields[31].Descriptor()
+	usagelogDescUserAgent := usagelogFields[32].Descriptor()
 	// usagelog.UserAgentValidator is a validator for the "user_agent" field. It is called by the builders before save.
 	usagelog.UserAgentValidator = usagelogDescUserAgent.Validators[0].(func(string) error)
 	// usagelogDescIPAddress is the schema descriptor for ip_address field.
-	usagelogDescIPAddress := usagelogFields[32].Descriptor()
+	usagelogDescIPAddress := usagelogFields[33].Descriptor()
 	// usagelog.IPAddressValidator is a validator for the "ip_address" field. It is called by the builders before save.
 	usagelog.IPAddressValidator = usagelogDescIPAddress.Validators[0].(func(string) error)
 	// usagelogDescImageCount is the schema descriptor for image_count field.
-	usagelogDescImageCount := usagelogFields[33].Descriptor()
+	usagelogDescImageCount := usagelogFields[34].Descriptor()
 	// usagelog.DefaultImageCount holds the default value on creation for the image_count field.
 	usagelog.DefaultImageCount = usagelogDescImageCount.Default.(int)
 	// usagelogDescImageSize is the schema descriptor for image_size field.
-	usagelogDescImageSize := usagelogFields[34].Descriptor()
+	usagelogDescImageSize := usagelogFields[35].Descriptor()
 	// usagelog.ImageSizeValidator is a validator for the "image_size" field. It is called by the builders before save.
 	usagelog.ImageSizeValidator = usagelogDescImageSize.Validators[0].(func(string) error)
 	// usagelogDescImageInputSize is the schema descriptor for image_input_size field.
-	usagelogDescImageInputSize := usagelogFields[35].Descriptor()
+	usagelogDescImageInputSize := usagelogFields[36].Descriptor()
 	// usagelog.ImageInputSizeValidator is a validator for the "image_input_size" field. It is called by the builders before save.
 	usagelog.ImageInputSizeValidator = usagelogDescImageInputSize.Validators[0].(func(string) error)
 	// usagelogDescImageOutputSize is the schema descriptor for image_output_size field.
-	usagelogDescImageOutputSize := usagelogFields[36].Descriptor()
+	usagelogDescImageOutputSize := usagelogFields[37].Descriptor()
 	// usagelog.ImageOutputSizeValidator is a validator for the "image_output_size" field. It is called by the builders before save.
 	usagelog.ImageOutputSizeValidator = usagelogDescImageOutputSize.Validators[0].(func(string) error)
 	// usagelogDescImageSizeSource is the schema descriptor for image_size_source field.
-	usagelogDescImageSizeSource := usagelogFields[37].Descriptor()
+	usagelogDescImageSizeSource := usagelogFields[38].Descriptor()
 	// usagelog.ImageSizeSourceValidator is a validator for the "image_size_source" field. It is called by the builders before save.
 	usagelog.ImageSizeSourceValidator = usagelogDescImageSizeSource.Validators[0].(func(string) error)
 	// usagelogDescCacheTTLOverridden is the schema descriptor for cache_ttl_overridden field.
-	usagelogDescCacheTTLOverridden := usagelogFields[39].Descriptor()
+	usagelogDescCacheTTLOverridden := usagelogFields[40].Descriptor()
 	// usagelog.DefaultCacheTTLOverridden holds the default value on creation for the cache_ttl_overridden field.
 	usagelog.DefaultCacheTTLOverridden = usagelogDescCacheTTLOverridden.Default.(bool)
 	// usagelogDescCreatedAt is the schema descriptor for created_at field.
-	usagelogDescCreatedAt := usagelogFields[40].Descriptor()
+	usagelogDescCreatedAt := usagelogFields[41].Descriptor()
 	// usagelog.DefaultCreatedAt holds the default value on creation for the created_at field.
 	usagelog.DefaultCreatedAt = usagelogDescCreatedAt.Default.(func() time.Time)
 	userMixin := schema.User{}.Mixin()

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -898,6 +898,10 @@ func init() {
 	groupDescKiroCreditTargetUsd := groupFields[36].Descriptor()
 	// group.DefaultKiroCreditTargetUsd holds the default value on creation for the kiro_credit_target_usd field.
 	group.DefaultKiroCreditTargetUsd = groupDescKiroCreditTargetUsd.Default.(float64)
+	// groupDescKiroCacheForceRatioCenter is the schema descriptor for kiro_cache_force_ratio_center field.
+	groupDescKiroCacheForceRatioCenter := groupFields[37].Descriptor()
+	// group.DefaultKiroCacheForceRatioCenter holds the default value on creation for the kiro_cache_force_ratio_center field.
+	group.DefaultKiroCacheForceRatioCenter = groupDescKiroCacheForceRatioCenter.Default.(float64)
 	idempotencyrecordMixin := schema.IdempotencyRecord{}.Mixin()
 	idempotencyrecordMixinFields0 := idempotencyrecordMixin[0].Fields()
 	_ = idempotencyrecordMixinFields0

--- a/backend/ent/schema/group.go
+++ b/backend/ent/schema/group.go
@@ -179,6 +179,10 @@ func (Group) Fields() []ent.Field {
 			SchemaType(map[string]string{dialect.Postgres: "decimal(5,4)"}).
 			Default(1.0).
 			Comment("Kiro 模拟缓存生效比例，范围 0-1（仅 kiro 分组生效）"),
+		field.Float("kiro_credit_target_usd").
+			SchemaType(map[string]string{dialect.Postgres: "decimal(8,4)"}).
+			Default(0).
+			Comment("Kiro 反向 token 缩放锚定单价：每 credit 对应 USD 余额（0=禁用）"),
 	}
 }
 

--- a/backend/ent/schema/group.go
+++ b/backend/ent/schema/group.go
@@ -183,6 +183,10 @@ func (Group) Fields() []ent.Field {
 			SchemaType(map[string]string{dialect.Postgres: "decimal(8,4)"}).
 			Default(0).
 			Comment("Kiro 反向 token 缩放锚定单价：每 credit 对应 USD 余额（0=禁用）"),
+		field.Float("kiro_cache_force_ratio_center").
+			SchemaType(map[string]string{dialect.Postgres: "decimal(5,4)"}).
+			Default(0).
+			Comment("Kiro 缓存强制比例中位数（0=禁用）。>0 时把模拟缓存分布重塑成 Anthropic-like 形态（input 极小、cache_read 占大头）；配合 credit 反向缩放计费时为纯展示口径，不改变最终扣费（=credits×单价）"),
 	}
 }
 

--- a/backend/ent/schema/usage_log.go
+++ b/backend/ent/schema/usage_log.go
@@ -78,6 +78,12 @@ func (UsageLog) Fields() []ent.Field {
 		field.Int("cache_creation_1h_tokens").
 			Default(0),
 
+		// Kiro 上游 meteringEvent.usage 累加值（仅 platform=kiro 有值，其他 nullable）
+		field.Float("kiro_credits").
+			SchemaType(map[string]string{dialect.Postgres: "decimal(10,4)"}).
+			Optional().
+			Nillable(),
+
 		// 成本字段
 		field.Float("input_cost").
 			Default(0).

--- a/backend/ent/usagelog.go
+++ b/backend/ent/usagelog.go
@@ -61,6 +61,8 @@ type UsageLog struct {
 	CacheCreation5mTokens int `json:"cache_creation_5m_tokens,omitempty"`
 	// CacheCreation1hTokens holds the value of the "cache_creation_1h_tokens" field.
 	CacheCreation1hTokens int `json:"cache_creation_1h_tokens,omitempty"`
+	// KiroCredits holds the value of the "kiro_credits" field.
+	KiroCredits *float64 `json:"kiro_credits,omitempty"`
 	// InputCost holds the value of the "input_cost" field.
 	InputCost float64 `json:"input_cost,omitempty"`
 	// OutputCost holds the value of the "output_cost" field.
@@ -192,7 +194,7 @@ func (*UsageLog) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case usagelog.FieldStream, usagelog.FieldCacheTTLOverridden:
 			values[i] = new(sql.NullBool)
-		case usagelog.FieldInputCost, usagelog.FieldOutputCost, usagelog.FieldCacheCreationCost, usagelog.FieldCacheReadCost, usagelog.FieldTotalCost, usagelog.FieldActualCost, usagelog.FieldRateMultiplier, usagelog.FieldAccountRateMultiplier:
+		case usagelog.FieldKiroCredits, usagelog.FieldInputCost, usagelog.FieldOutputCost, usagelog.FieldCacheCreationCost, usagelog.FieldCacheReadCost, usagelog.FieldTotalCost, usagelog.FieldActualCost, usagelog.FieldRateMultiplier, usagelog.FieldAccountRateMultiplier:
 			values[i] = new(sql.NullFloat64)
 		case usagelog.FieldID, usagelog.FieldUserID, usagelog.FieldAPIKeyID, usagelog.FieldAccountID, usagelog.FieldChannelID, usagelog.FieldGroupID, usagelog.FieldSubscriptionID, usagelog.FieldInputTokens, usagelog.FieldOutputTokens, usagelog.FieldCacheCreationTokens, usagelog.FieldCacheReadTokens, usagelog.FieldCacheCreation5mTokens, usagelog.FieldCacheCreation1hTokens, usagelog.FieldBillingType, usagelog.FieldDurationMs, usagelog.FieldFirstTokenMs, usagelog.FieldImageCount:
 			values[i] = new(sql.NullInt64)
@@ -342,6 +344,13 @@ func (_m *UsageLog) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field cache_creation_1h_tokens", values[i])
 			} else if value.Valid {
 				_m.CacheCreation1hTokens = int(value.Int64)
+			}
+		case usagelog.FieldKiroCredits:
+			if value, ok := values[i].(*sql.NullFloat64); !ok {
+				return fmt.Errorf("unexpected type %T for field kiro_credits", values[i])
+			} else if value.Valid {
+				_m.KiroCredits = new(float64)
+				*_m.KiroCredits = value.Float64
 			}
 		case usagelog.FieldInputCost:
 			if value, ok := values[i].(*sql.NullFloat64); !ok {
@@ -619,6 +628,11 @@ func (_m *UsageLog) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("cache_creation_1h_tokens=")
 	builder.WriteString(fmt.Sprintf("%v", _m.CacheCreation1hTokens))
+	builder.WriteString(", ")
+	if v := _m.KiroCredits; v != nil {
+		builder.WriteString("kiro_credits=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
 	builder.WriteString(", ")
 	builder.WriteString("input_cost=")
 	builder.WriteString(fmt.Sprintf("%v", _m.InputCost))

--- a/backend/ent/usagelog/usagelog.go
+++ b/backend/ent/usagelog/usagelog.go
@@ -52,6 +52,8 @@ const (
 	FieldCacheCreation5mTokens = "cache_creation_5m_tokens"
 	// FieldCacheCreation1hTokens holds the string denoting the cache_creation_1h_tokens field in the database.
 	FieldCacheCreation1hTokens = "cache_creation_1h_tokens"
+	// FieldKiroCredits holds the string denoting the kiro_credits field in the database.
+	FieldKiroCredits = "kiro_credits"
 	// FieldInputCost holds the string denoting the input_cost field in the database.
 	FieldInputCost = "input_cost"
 	// FieldOutputCost holds the string denoting the output_cost field in the database.
@@ -167,6 +169,7 @@ var Columns = []string{
 	FieldCacheReadTokens,
 	FieldCacheCreation5mTokens,
 	FieldCacheCreation1hTokens,
+	FieldKiroCredits,
 	FieldInputCost,
 	FieldOutputCost,
 	FieldCacheCreationCost,
@@ -367,6 +370,11 @@ func ByCacheCreation5mTokens(opts ...sql.OrderTermOption) OrderOption {
 // ByCacheCreation1hTokens orders the results by the cache_creation_1h_tokens field.
 func ByCacheCreation1hTokens(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCacheCreation1hTokens, opts...).ToFunc()
+}
+
+// ByKiroCredits orders the results by the kiro_credits field.
+func ByKiroCredits(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldKiroCredits, opts...).ToFunc()
 }
 
 // ByInputCost orders the results by the input_cost field.

--- a/backend/ent/usagelog/where.go
+++ b/backend/ent/usagelog/where.go
@@ -150,6 +150,11 @@ func CacheCreation1hTokens(v int) predicate.UsageLog {
 	return predicate.UsageLog(sql.FieldEQ(FieldCacheCreation1hTokens, v))
 }
 
+// KiroCredits applies equality check predicate on the "kiro_credits" field. It's identical to KiroCreditsEQ.
+func KiroCredits(v float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldEQ(FieldKiroCredits, v))
+}
+
 // InputCost applies equality check predicate on the "input_cost" field. It's identical to InputCostEQ.
 func InputCost(v float64) predicate.UsageLog {
 	return predicate.UsageLog(sql.FieldEQ(FieldInputCost, v))
@@ -1168,6 +1173,56 @@ func CacheCreation1hTokensLT(v int) predicate.UsageLog {
 // CacheCreation1hTokensLTE applies the LTE predicate on the "cache_creation_1h_tokens" field.
 func CacheCreation1hTokensLTE(v int) predicate.UsageLog {
 	return predicate.UsageLog(sql.FieldLTE(FieldCacheCreation1hTokens, v))
+}
+
+// KiroCreditsEQ applies the EQ predicate on the "kiro_credits" field.
+func KiroCreditsEQ(v float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldEQ(FieldKiroCredits, v))
+}
+
+// KiroCreditsNEQ applies the NEQ predicate on the "kiro_credits" field.
+func KiroCreditsNEQ(v float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldNEQ(FieldKiroCredits, v))
+}
+
+// KiroCreditsIn applies the In predicate on the "kiro_credits" field.
+func KiroCreditsIn(vs ...float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldIn(FieldKiroCredits, vs...))
+}
+
+// KiroCreditsNotIn applies the NotIn predicate on the "kiro_credits" field.
+func KiroCreditsNotIn(vs ...float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldNotIn(FieldKiroCredits, vs...))
+}
+
+// KiroCreditsGT applies the GT predicate on the "kiro_credits" field.
+func KiroCreditsGT(v float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldGT(FieldKiroCredits, v))
+}
+
+// KiroCreditsGTE applies the GTE predicate on the "kiro_credits" field.
+func KiroCreditsGTE(v float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldGTE(FieldKiroCredits, v))
+}
+
+// KiroCreditsLT applies the LT predicate on the "kiro_credits" field.
+func KiroCreditsLT(v float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldLT(FieldKiroCredits, v))
+}
+
+// KiroCreditsLTE applies the LTE predicate on the "kiro_credits" field.
+func KiroCreditsLTE(v float64) predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldLTE(FieldKiroCredits, v))
+}
+
+// KiroCreditsIsNil applies the IsNil predicate on the "kiro_credits" field.
+func KiroCreditsIsNil() predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldIsNull(FieldKiroCredits))
+}
+
+// KiroCreditsNotNil applies the NotNil predicate on the "kiro_credits" field.
+func KiroCreditsNotNil() predicate.UsageLog {
+	return predicate.UsageLog(sql.FieldNotNull(FieldKiroCredits))
 }
 
 // InputCostEQ applies the EQ predicate on the "input_cost" field.

--- a/backend/ent/usagelog_create.go
+++ b/backend/ent/usagelog_create.go
@@ -253,6 +253,20 @@ func (_c *UsageLogCreate) SetNillableCacheCreation1hTokens(v *int) *UsageLogCrea
 	return _c
 }
 
+// SetKiroCredits sets the "kiro_credits" field.
+func (_c *UsageLogCreate) SetKiroCredits(v float64) *UsageLogCreate {
+	_c.mutation.SetKiroCredits(v)
+	return _c
+}
+
+// SetNillableKiroCredits sets the "kiro_credits" field if the given value is not nil.
+func (_c *UsageLogCreate) SetNillableKiroCredits(v *float64) *UsageLogCreate {
+	if v != nil {
+		_c.SetKiroCredits(*v)
+	}
+	return _c
+}
+
 // SetInputCost sets the "input_cost" field.
 func (_c *UsageLogCreate) SetInputCost(v float64) *UsageLogCreate {
 	_c.mutation.SetInputCost(v)
@@ -915,6 +929,10 @@ func (_c *UsageLogCreate) createSpec() (*UsageLog, *sqlgraph.CreateSpec) {
 		_spec.SetField(usagelog.FieldCacheCreation1hTokens, field.TypeInt, value)
 		_node.CacheCreation1hTokens = value
 	}
+	if value, ok := _c.mutation.KiroCredits(); ok {
+		_spec.SetField(usagelog.FieldKiroCredits, field.TypeFloat64, value)
+		_node.KiroCredits = &value
+	}
 	if value, ok := _c.mutation.InputCost(); ok {
 		_spec.SetField(usagelog.FieldInputCost, field.TypeFloat64, value)
 		_node.InputCost = value
@@ -1455,6 +1473,30 @@ func (u *UsageLogUpsert) UpdateCacheCreation1hTokens() *UsageLogUpsert {
 // AddCacheCreation1hTokens adds v to the "cache_creation_1h_tokens" field.
 func (u *UsageLogUpsert) AddCacheCreation1hTokens(v int) *UsageLogUpsert {
 	u.Add(usagelog.FieldCacheCreation1hTokens, v)
+	return u
+}
+
+// SetKiroCredits sets the "kiro_credits" field.
+func (u *UsageLogUpsert) SetKiroCredits(v float64) *UsageLogUpsert {
+	u.Set(usagelog.FieldKiroCredits, v)
+	return u
+}
+
+// UpdateKiroCredits sets the "kiro_credits" field to the value that was provided on create.
+func (u *UsageLogUpsert) UpdateKiroCredits() *UsageLogUpsert {
+	u.SetExcluded(usagelog.FieldKiroCredits)
+	return u
+}
+
+// AddKiroCredits adds v to the "kiro_credits" field.
+func (u *UsageLogUpsert) AddKiroCredits(v float64) *UsageLogUpsert {
+	u.Add(usagelog.FieldKiroCredits, v)
+	return u
+}
+
+// ClearKiroCredits clears the value of the "kiro_credits" field.
+func (u *UsageLogUpsert) ClearKiroCredits() *UsageLogUpsert {
+	u.SetNull(usagelog.FieldKiroCredits)
 	return u
 }
 
@@ -2255,6 +2297,34 @@ func (u *UsageLogUpsertOne) AddCacheCreation1hTokens(v int) *UsageLogUpsertOne {
 func (u *UsageLogUpsertOne) UpdateCacheCreation1hTokens() *UsageLogUpsertOne {
 	return u.Update(func(s *UsageLogUpsert) {
 		s.UpdateCacheCreation1hTokens()
+	})
+}
+
+// SetKiroCredits sets the "kiro_credits" field.
+func (u *UsageLogUpsertOne) SetKiroCredits(v float64) *UsageLogUpsertOne {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.SetKiroCredits(v)
+	})
+}
+
+// AddKiroCredits adds v to the "kiro_credits" field.
+func (u *UsageLogUpsertOne) AddKiroCredits(v float64) *UsageLogUpsertOne {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.AddKiroCredits(v)
+	})
+}
+
+// UpdateKiroCredits sets the "kiro_credits" field to the value that was provided on create.
+func (u *UsageLogUpsertOne) UpdateKiroCredits() *UsageLogUpsertOne {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.UpdateKiroCredits()
+	})
+}
+
+// ClearKiroCredits clears the value of the "kiro_credits" field.
+func (u *UsageLogUpsertOne) ClearKiroCredits() *UsageLogUpsertOne {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.ClearKiroCredits()
 	})
 }
 
@@ -3285,6 +3355,34 @@ func (u *UsageLogUpsertBulk) AddCacheCreation1hTokens(v int) *UsageLogUpsertBulk
 func (u *UsageLogUpsertBulk) UpdateCacheCreation1hTokens() *UsageLogUpsertBulk {
 	return u.Update(func(s *UsageLogUpsert) {
 		s.UpdateCacheCreation1hTokens()
+	})
+}
+
+// SetKiroCredits sets the "kiro_credits" field.
+func (u *UsageLogUpsertBulk) SetKiroCredits(v float64) *UsageLogUpsertBulk {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.SetKiroCredits(v)
+	})
+}
+
+// AddKiroCredits adds v to the "kiro_credits" field.
+func (u *UsageLogUpsertBulk) AddKiroCredits(v float64) *UsageLogUpsertBulk {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.AddKiroCredits(v)
+	})
+}
+
+// UpdateKiroCredits sets the "kiro_credits" field to the value that was provided on create.
+func (u *UsageLogUpsertBulk) UpdateKiroCredits() *UsageLogUpsertBulk {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.UpdateKiroCredits()
+	})
+}
+
+// ClearKiroCredits clears the value of the "kiro_credits" field.
+func (u *UsageLogUpsertBulk) ClearKiroCredits() *UsageLogUpsertBulk {
+	return u.Update(func(s *UsageLogUpsert) {
+		s.ClearKiroCredits()
 	})
 }
 

--- a/backend/ent/usagelog_update.go
+++ b/backend/ent/usagelog_update.go
@@ -395,6 +395,33 @@ func (_u *UsageLogUpdate) AddCacheCreation1hTokens(v int) *UsageLogUpdate {
 	return _u
 }
 
+// SetKiroCredits sets the "kiro_credits" field.
+func (_u *UsageLogUpdate) SetKiroCredits(v float64) *UsageLogUpdate {
+	_u.mutation.ResetKiroCredits()
+	_u.mutation.SetKiroCredits(v)
+	return _u
+}
+
+// SetNillableKiroCredits sets the "kiro_credits" field if the given value is not nil.
+func (_u *UsageLogUpdate) SetNillableKiroCredits(v *float64) *UsageLogUpdate {
+	if v != nil {
+		_u.SetKiroCredits(*v)
+	}
+	return _u
+}
+
+// AddKiroCredits adds value to the "kiro_credits" field.
+func (_u *UsageLogUpdate) AddKiroCredits(v float64) *UsageLogUpdate {
+	_u.mutation.AddKiroCredits(v)
+	return _u
+}
+
+// ClearKiroCredits clears the value of the "kiro_credits" field.
+func (_u *UsageLogUpdate) ClearKiroCredits() *UsageLogUpdate {
+	_u.mutation.ClearKiroCredits()
+	return _u
+}
+
 // SetInputCost sets the "input_cost" field.
 func (_u *UsageLogUpdate) SetInputCost(v float64) *UsageLogUpdate {
 	_u.mutation.ResetInputCost()
@@ -1084,6 +1111,15 @@ func (_u *UsageLogUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	if value, ok := _u.mutation.AddedCacheCreation1hTokens(); ok {
 		_spec.AddField(usagelog.FieldCacheCreation1hTokens, field.TypeInt, value)
 	}
+	if value, ok := _u.mutation.KiroCredits(); ok {
+		_spec.SetField(usagelog.FieldKiroCredits, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.AddedKiroCredits(); ok {
+		_spec.AddField(usagelog.FieldKiroCredits, field.TypeFloat64, value)
+	}
+	if _u.mutation.KiroCreditsCleared() {
+		_spec.ClearField(usagelog.FieldKiroCredits, field.TypeFloat64)
+	}
 	if value, ok := _u.mutation.InputCost(); ok {
 		_spec.SetField(usagelog.FieldInputCost, field.TypeFloat64, value)
 	}
@@ -1738,6 +1774,33 @@ func (_u *UsageLogUpdateOne) SetNillableCacheCreation1hTokens(v *int) *UsageLogU
 // AddCacheCreation1hTokens adds value to the "cache_creation_1h_tokens" field.
 func (_u *UsageLogUpdateOne) AddCacheCreation1hTokens(v int) *UsageLogUpdateOne {
 	_u.mutation.AddCacheCreation1hTokens(v)
+	return _u
+}
+
+// SetKiroCredits sets the "kiro_credits" field.
+func (_u *UsageLogUpdateOne) SetKiroCredits(v float64) *UsageLogUpdateOne {
+	_u.mutation.ResetKiroCredits()
+	_u.mutation.SetKiroCredits(v)
+	return _u
+}
+
+// SetNillableKiroCredits sets the "kiro_credits" field if the given value is not nil.
+func (_u *UsageLogUpdateOne) SetNillableKiroCredits(v *float64) *UsageLogUpdateOne {
+	if v != nil {
+		_u.SetKiroCredits(*v)
+	}
+	return _u
+}
+
+// AddKiroCredits adds value to the "kiro_credits" field.
+func (_u *UsageLogUpdateOne) AddKiroCredits(v float64) *UsageLogUpdateOne {
+	_u.mutation.AddKiroCredits(v)
+	return _u
+}
+
+// ClearKiroCredits clears the value of the "kiro_credits" field.
+func (_u *UsageLogUpdateOne) ClearKiroCredits() *UsageLogUpdateOne {
+	_u.mutation.ClearKiroCredits()
 	return _u
 }
 
@@ -2459,6 +2522,15 @@ func (_u *UsageLogUpdateOne) sqlSave(ctx context.Context) (_node *UsageLog, err 
 	}
 	if value, ok := _u.mutation.AddedCacheCreation1hTokens(); ok {
 		_spec.AddField(usagelog.FieldCacheCreation1hTokens, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.KiroCredits(); ok {
+		_spec.SetField(usagelog.FieldKiroCredits, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.AddedKiroCredits(); ok {
+		_spec.AddField(usagelog.FieldKiroCredits, field.TypeFloat64, value)
+	}
+	if _u.mutation.KiroCreditsCleared() {
+		_spec.ClearField(usagelog.FieldKiroCredits, field.TypeFloat64)
 	}
 	if value, ok := _u.mutation.InputCost(); ok {
 		_spec.SetField(usagelog.FieldInputCost, field.TypeFloat64, value)

--- a/backend/internal/handler/admin/group_handler.go
+++ b/backend/internal/handler/admin/group_handler.go
@@ -122,7 +122,8 @@ type CreateGroupRequest struct {
 	KiroStickySessionTTLSeconds *int     `json:"kiro_sticky_session_ttl_seconds"`
 	KiroCacheEmulationRatio     *float64 `json:"kiro_cache_emulation_ratio"`
 	// Kiro 反向 token 缩放：每 credit 对应 USD 余额（0=禁用，仅 platform=kiro 生效）
-	KiroCreditTargetUSD *float64 `json:"kiro_credit_target_usd"`
+	KiroCreditTargetUSD       *float64 `json:"kiro_credit_target_usd"`
+	KiroCacheForceRatioCenter *float64 `json:"kiro_cache_force_ratio_center"`
 	// 从指定分组复制账号（创建后自动绑定）
 	CopyAccountsFromGroupIDs []int64 `json:"copy_accounts_from_group_ids"`
 }
@@ -170,7 +171,8 @@ type UpdateGroupRequest struct {
 	KiroStickySessionTTLSeconds *int     `json:"kiro_sticky_session_ttl_seconds"`
 	KiroCacheEmulationRatio     *float64 `json:"kiro_cache_emulation_ratio"`
 	// Kiro 反向 token 缩放：每 credit 对应 USD 余额（仅 platform=kiro 生效）
-	KiroCreditTargetUSD *float64 `json:"kiro_credit_target_usd"`
+	KiroCreditTargetUSD       *float64 `json:"kiro_credit_target_usd"`
+	KiroCacheForceRatioCenter *float64 `json:"kiro_cache_force_ratio_center"`
 	// 从指定分组复制账号（同步操作：先清空当前分组的账号绑定，再绑定源分组的账号）
 	CopyAccountsFromGroupIDs []int64 `json:"copy_accounts_from_group_ids"`
 }
@@ -326,6 +328,7 @@ func (h *GroupHandler) Create(c *gin.Context) {
 		KiroStickySessionTTLSeconds:     req.KiroStickySessionTTLSeconds,
 		KiroCacheEmulationRatio:         req.KiroCacheEmulationRatio,
 		KiroCreditTargetUSD:             req.KiroCreditTargetUSD,
+		KiroCacheForceRatioCenter:       req.KiroCacheForceRatioCenter,
 		CopyAccountsFromGroupIDs:        req.CopyAccountsFromGroupIDs,
 	})
 	if err != nil {
@@ -387,6 +390,7 @@ func (h *GroupHandler) Update(c *gin.Context) {
 		KiroStickySessionTTLSeconds:     req.KiroStickySessionTTLSeconds,
 		KiroCacheEmulationRatio:         req.KiroCacheEmulationRatio,
 		KiroCreditTargetUSD:             req.KiroCreditTargetUSD,
+		KiroCacheForceRatioCenter:       req.KiroCacheForceRatioCenter,
 		CopyAccountsFromGroupIDs:        req.CopyAccountsFromGroupIDs,
 	})
 	if err != nil {

--- a/backend/internal/handler/admin/group_handler.go
+++ b/backend/internal/handler/admin/group_handler.go
@@ -121,6 +121,8 @@ type CreateGroupRequest struct {
 	KiroAutoStickyEnabled       *bool    `json:"kiro_auto_sticky_enabled"`
 	KiroStickySessionTTLSeconds *int     `json:"kiro_sticky_session_ttl_seconds"`
 	KiroCacheEmulationRatio     *float64 `json:"kiro_cache_emulation_ratio"`
+	// Kiro 反向 token 缩放：每 credit 对应 USD 余额（0=禁用，仅 platform=kiro 生效）
+	KiroCreditTargetUSD *float64 `json:"kiro_credit_target_usd"`
 	// 从指定分组复制账号（创建后自动绑定）
 	CopyAccountsFromGroupIDs []int64 `json:"copy_accounts_from_group_ids"`
 }
@@ -167,6 +169,8 @@ type UpdateGroupRequest struct {
 	KiroAutoStickyEnabled       *bool    `json:"kiro_auto_sticky_enabled"`
 	KiroStickySessionTTLSeconds *int     `json:"kiro_sticky_session_ttl_seconds"`
 	KiroCacheEmulationRatio     *float64 `json:"kiro_cache_emulation_ratio"`
+	// Kiro 反向 token 缩放：每 credit 对应 USD 余额（仅 platform=kiro 生效）
+	KiroCreditTargetUSD *float64 `json:"kiro_credit_target_usd"`
 	// 从指定分组复制账号（同步操作：先清空当前分组的账号绑定，再绑定源分组的账号）
 	CopyAccountsFromGroupIDs []int64 `json:"copy_accounts_from_group_ids"`
 }
@@ -321,6 +325,7 @@ func (h *GroupHandler) Create(c *gin.Context) {
 		KiroAutoStickyEnabled:           req.KiroAutoStickyEnabled,
 		KiroStickySessionTTLSeconds:     req.KiroStickySessionTTLSeconds,
 		KiroCacheEmulationRatio:         req.KiroCacheEmulationRatio,
+		KiroCreditTargetUSD:             req.KiroCreditTargetUSD,
 		CopyAccountsFromGroupIDs:        req.CopyAccountsFromGroupIDs,
 	})
 	if err != nil {
@@ -381,6 +386,7 @@ func (h *GroupHandler) Update(c *gin.Context) {
 		KiroAutoStickyEnabled:           req.KiroAutoStickyEnabled,
 		KiroStickySessionTTLSeconds:     req.KiroStickySessionTTLSeconds,
 		KiroCacheEmulationRatio:         req.KiroCacheEmulationRatio,
+		KiroCreditTargetUSD:             req.KiroCreditTargetUSD,
 		CopyAccountsFromGroupIDs:        req.CopyAccountsFromGroupIDs,
 	})
 	if err != nil {

--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -195,6 +195,7 @@ func groupFromServiceBase(g *service.Group) Group {
 		KiroAutoStickyEnabled:           g.EffectiveKiroAutoStickyEnabled(),
 		KiroStickySessionTTLSeconds:     g.EffectiveKiroStickySessionTTLSeconds(),
 		KiroCacheEmulationRatio:         g.EffectiveKiroCacheEmulationRatio(),
+		KiroCreditTargetUSD:             g.EffectiveKiroCreditTargetUSD(),
 		CreatedAt:                       g.CreatedAt,
 		UpdatedAt:                       g.UpdatedAt,
 	}

--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -196,6 +196,7 @@ func groupFromServiceBase(g *service.Group) Group {
 		KiroStickySessionTTLSeconds:     g.EffectiveKiroStickySessionTTLSeconds(),
 		KiroCacheEmulationRatio:         g.EffectiveKiroCacheEmulationRatio(),
 		KiroCreditTargetUSD:             g.EffectiveKiroCreditTargetUSD(),
+		KiroCacheForceRatioCenter:       g.EffectiveKiroCacheForceRatioCenter(),
 		CreatedAt:                       g.CreatedAt,
 		UpdatedAt:                       g.UpdatedAt,
 	}

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -125,6 +125,7 @@ type Group struct {
 	KiroAutoStickyEnabled       bool    `json:"kiro_auto_sticky_enabled"`
 	KiroStickySessionTTLSeconds int     `json:"kiro_sticky_session_ttl_seconds"`
 	KiroCacheEmulationRatio     float64 `json:"kiro_cache_emulation_ratio"`
+	KiroCacheForceRatioCenter   float64 `json:"kiro_cache_force_ratio_center"`
 
 	// Kiro 反向 token 缩放：每 credit 对应 USD 余额（0=禁用，仅 platform=kiro 生效）
 	KiroCreditTargetUSD float64 `json:"kiro_credit_target_usd"`

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -126,6 +126,9 @@ type Group struct {
 	KiroStickySessionTTLSeconds int     `json:"kiro_sticky_session_ttl_seconds"`
 	KiroCacheEmulationRatio     float64 `json:"kiro_cache_emulation_ratio"`
 
+	// Kiro 反向 token 缩放：每 credit 对应 USD 余额（0=禁用，仅 platform=kiro 生效）
+	KiroCreditTargetUSD float64 `json:"kiro_credit_target_usd"`
+
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/backend/internal/pkg/kiro/translator.go
+++ b/backend/internal/pkg/kiro/translator.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"os"
 	"regexp"
@@ -82,6 +83,9 @@ type Usage struct {
 	CacheCreationInputTokens   int
 	CacheCreation5mInputTokens int
 	CacheCreation1hInputTokens int
+	// KiroCredits 来自上游 meteringEvent 帧的 usage 字段（浮点 credits 累加）。
+	// Kiro 真实计费的唯一可信来源，用于反向 token 缩放锚定金额。
+	KiroCredits float64
 }
 
 type StreamResult struct {
@@ -104,6 +108,15 @@ type KiroRequestContext struct {
 	StructuredOutputUserHint string
 	StopSequences            []string
 	MaxOutputTokens          int
+
+	// ReverseScaling 配置反向 token 缩放：
+	//   - TargetUSD > 0 启用，每 credit 对应的 sub2api USD 余额
+	//   - 流结束时拿到 KiroCredits 后，把 4 个 token 字段 × K 让计费金额 = credits × TargetUSD
+	//   - 由 service 层 (kiroUsageToClaude 之前) 注入，translator 不读 group / model 配置
+	ReverseScalingTargetUSD float64
+	// ReverseScalingPrices 是 Anthropic 标准价 (input/output/cc/cr per M tokens)，
+	// 由 service 层按 model 类别选好后传入。
+	ReverseScalingPrices [4]float64
 }
 
 type KiroBuildResult struct {
@@ -501,6 +514,7 @@ func ParseNonStreamingEventStreamWithContext(body io.Reader, model string, reque
 	if requestCtx.CacheEmulationUsage != nil {
 		usage = mergeKiroCacheEmulationUsage(usage, requestCtx.CacheEmulationUsage)
 	}
+	usage = applyKiroReverseScalingUsage(usage, requestCtx)
 	return &ParseResult{
 		ResponseBody: buildClaudeResponse(content, toolUses, model, usage, stopReason, requestCtx),
 		Usage:        usage,
@@ -1168,6 +1182,9 @@ func StreamEventStreamAsAnthropicWithContext(ctx context.Context, body io.Reader
 	if requestCtx.CacheEmulationUsage != nil {
 		usage = mergeKiroCacheEmulationUsage(usage, requestCtx.CacheEmulationUsage)
 	}
+	// 反向 token 缩放：让 token × Anthropic价 = credits × TargetUSD
+	// 必须在构建 finalUsageMap 之前，确保响应给客户端的 token 与库里的一致。
+	usage = applyKiroReverseScalingUsage(usage, requestCtx)
 	if stopReason == "" {
 		if len(emittedToolContents) > 0 {
 			stopReason = "tool_use"
@@ -1183,6 +1200,12 @@ func StreamEventStreamAsAnthropicWithContext(ctx context.Context, body io.Reader
 		"output_tokens":               usage.OutputTokens,
 		"cache_read_input_tokens":     usage.CacheReadInputTokens,
 		"cache_creation_input_tokens": usage.CacheCreationInputTokens,
+	}
+	// sub2api 内部通道：把 Kiro 真实 credits 透传给 gateway 层（经 SSE message_delta），
+	// 用于 usage_logs.kiro_credits 持久化。gateway 在转发给客户端前会剥离该字段
+	// （见 gateway_service 的 stripSub2apiInternalUsageFields / SSE 重写路径）。
+	if usage.KiroCredits > 0 {
+		finalUsageMap["_sub2api_kiro_credits"] = usage.KiroCredits
 	}
 	addKiroCacheUsageFields(finalUsageMap, usage)
 	if err := writeEvent("message_delta", map[string]any{
@@ -3126,6 +3149,8 @@ func buildKiroClaudeUsageMap(usage Usage) map[string]any {
 		"output_tokens":           usage.OutputTokens,
 		"cache_read_input_tokens": usage.CacheReadInputTokens,
 	}
+	// 注意：不在这里透传 _sub2api_kiro_credits。非流式响应体原样发给客户端，
+	// 而非流式计费走 ParseResult.Usage 返回值，无需经响应体中转。
 	if usage.CacheCreationInputTokens > 0 {
 		usageMap["cache_creation_input_tokens"] = usage.CacheCreationInputTokens
 	}
@@ -3641,7 +3666,7 @@ func extractSemanticEvents(eventType string, event map[string]any, lastContentFr
 				SourceStopReason: sourceStopReason,
 			})
 		}
-	case "messageMetadataEvent", "metadataEvent", "supplementaryWebLinksEvent", "usageEvent", "messageStopEvent", "message_stop":
+	case "messageMetadataEvent", "metadataEvent", "supplementaryWebLinksEvent", "usageEvent", "messageStopEvent", "message_stop", "meteringEvent":
 		out = append(out, kiroSemanticEvent{
 			Type:             kiroSemanticUsage,
 			SourceEventType:  eventType,
@@ -4067,6 +4092,17 @@ func updateUsageFromEvent(usage *Usage, eventType string, event map[string]any) 
 	if value, ok := toInt(meta["totalTokens"]); ok && value > 0 {
 		usage.TotalTokens = value
 	}
+	// meteringEvent: { unit: "credit", unitPlural: "credits", usage: 0.685 }
+	// 一次请求可能下发多个 meteringEvent 帧，累加。usage 字段命名同 tokenUsage 父键，
+	// 但语义不同（是 credit 浮点数），用 toFloat 解析。
+	if eventType == "meteringEvent" {
+		// payload 可能在 event 顶层或 nested 在 eventType key 下。
+		if value, ok := toFloat(meta["usage"]); ok && value > 0 {
+			usage.KiroCredits += value
+		} else if value, ok := toFloat(event["usage"]); ok && value > 0 {
+			usage.KiroCredits += value
+		}
+	}
 }
 
 func readToolUses(primary, fallback map[string]any) []KiroToolUse {
@@ -4131,6 +4167,26 @@ func toInt(value any) (int, bool) {
 	}
 }
 
+// toFloat 把 SSE 事件 payload 中的数值字段转 float64。
+// meteringEvent.usage 是小数 credit 数（如 0.6856651423548923），必须用 float64 解析。
+func toFloat(value any) (float64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case json.Number:
+		f, err := v.Float64()
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
 func mergeKiroCacheEmulationUsage(base Usage, simulated *Usage) Usage {
 	if simulated == nil {
 		return base
@@ -4145,6 +4201,63 @@ func mergeKiroCacheEmulationUsage(base Usage, simulated *Usage) Usage {
 	base.CacheCreation1hInputTokens = simulated.CacheCreation1hInputTokens
 	base.TotalTokens = base.InputTokens + base.OutputTokens + base.CacheReadInputTokens + base.CacheCreationInputTokens
 	return base
+}
+
+// kiroReverseScalingMinK / MaxK 是反向缩放安全围栏。
+// 实测 K 范围 0.55-1.16，正常区间 [0.1, 5]；超出视为上游异常，不缩放。
+const (
+	kiroReverseScalingMinK = 0.1
+	kiroReverseScalingMaxK = 5.0
+)
+
+// applyKiroReverseScalingUsage 按 Anthropic 标准价反向缩放 4 个 token 字段，
+// 让 sum(token × Anthropic_price) = KiroCredits × TargetUSD。
+//
+// 触发条件：requestCtx.ReverseScalingTargetUSD > 0 且 usage.KiroCredits > 0
+// 兜底：K 不在 [0.1, 5] 范围 → 不缩放，原值返回。
+//
+// 参考算法：KIRO_REVERSE_SCALING_ALGORITHM.md
+func applyKiroReverseScalingUsage(usage Usage, ctx KiroRequestContext) Usage {
+	if ctx.ReverseScalingTargetUSD <= 0 || usage.KiroCredits <= 0 {
+		return usage
+	}
+	pIn, pOut, pCC, pCR := ctx.ReverseScalingPrices[0], ctx.ReverseScalingPrices[1], ctx.ReverseScalingPrices[2], ctx.ReverseScalingPrices[3]
+	if pIn <= 0 && pOut <= 0 && pCC <= 0 && pCR <= 0 {
+		return usage
+	}
+	inM := float64(usage.InputTokens) / 1e6
+	outM := float64(usage.OutputTokens) / 1e6
+	ccM := float64(usage.CacheCreationInputTokens) / 1e6
+	crM := float64(usage.CacheReadInputTokens) / 1e6
+	origCost := inM*pIn + outM*pOut + ccM*pCC + crM*pCR
+	if origCost <= 0 {
+		return usage
+	}
+	targetCost := usage.KiroCredits * ctx.ReverseScalingTargetUSD
+	K := targetCost / origCost
+	if K < kiroReverseScalingMinK || K > kiroReverseScalingMaxK {
+		return usage
+	}
+	usage.InputTokens = scaleKiroTokenValue(usage.InputTokens, K)
+	usage.OutputTokens = scaleKiroTokenValue(usage.OutputTokens, K)
+	usage.CacheCreationInputTokens = scaleKiroTokenValue(usage.CacheCreationInputTokens, K)
+	usage.CacheReadInputTokens = scaleKiroTokenValue(usage.CacheReadInputTokens, K)
+	usage.CacheCreation5mInputTokens = scaleKiroTokenValue(usage.CacheCreation5mInputTokens, K)
+	usage.CacheCreation1hInputTokens = scaleKiroTokenValue(usage.CacheCreation1hInputTokens, K)
+	usage.TotalTokens = usage.InputTokens + usage.OutputTokens + usage.CacheReadInputTokens + usage.CacheCreationInputTokens
+	return usage
+}
+
+// scaleKiroTokenValue 缩放单个 token 字段：原值 0 时不变，原值 > 0 时缩放后至少为 1。
+func scaleKiroTokenValue(orig int, K float64) int {
+	if orig <= 0 {
+		return orig
+	}
+	scaled := int(math.Round(float64(orig) * K))
+	if scaled < 1 {
+		return 1
+	}
+	return scaled
 }
 
 func addKiroCacheUsageFields(usageMap map[string]any, usage Usage) {

--- a/backend/internal/pkg/kiro/translator_test.go
+++ b/backend/internal/pkg/kiro/translator_test.go
@@ -1969,3 +1969,134 @@ func TestBuildKiroPayloadTrailingAssistantThenSystemStillAttachesTools(t *testin
 	require.Greater(t, gjson.GetBytes(payload, "conversationState.currentMessage.userInputMessage.userInputMessageContext.tools.#").Int(), int64(0))
 	require.Contains(t, gjson.GetBytes(payload, "conversationState.history.0.userInputMessage.content").String(), "TRAILING NOTE")
 }
+
+// =====================================================================================
+// Reverse-token-scaling tests
+// =====================================================================================
+
+// TestUpdateUsageFromEvent_MeteringEventAccumulates 验证 meteringEvent 的 usage
+// 字段（浮点 credit 数）被正确累加到 Usage.KiroCredits。
+func TestUpdateUsageFromEvent_MeteringEventAccumulates(t *testing.T) {
+	usage := &Usage{}
+	updateUsageFromEvent(usage, "meteringEvent", map[string]any{
+		"meteringEvent": map[string]any{
+			"unit":        "credit",
+			"unitPlural":  "credits",
+			"usage":       0.6856651423548923,
+		},
+	})
+	updateUsageFromEvent(usage, "meteringEvent", map[string]any{
+		"meteringEvent": map[string]any{
+			"usage": 0.7295404395688226,
+		},
+	})
+	expected := 0.6856651423548923 + 0.7295404395688226
+	require.InDelta(t, expected, usage.KiroCredits, 1e-9)
+}
+
+// TestApplyKiroReverseScalingUsage_AnchorsToTarget 验证按 Anthropic Opus 4.x
+// 标准价（5/25/6.25/0.5 per M）反向缩放后，token×price = credits×targetUSD。
+func TestApplyKiroReverseScalingUsage_AnchorsToTarget(t *testing.T) {
+	// pulbey52 实测样本（v3 后缩放前总 token，credits=2900）
+	usage := Usage{
+		InputTokens:              57889300,
+		OutputTokens:             574900,
+		CacheCreationInputTokens: 19065700,
+		CacheReadInputTokens:     145792400,
+		KiroCredits:              2900,
+	}
+	ctx := KiroRequestContext{
+		ReverseScalingTargetUSD: 0.04, // 用 0.04 测试方便（target = 2900 * 0.04 = $116）
+		ReverseScalingPrices:    [4]float64{5.0, 25.0, 6.25, 0.5},
+	}
+	scaled := applyKiroReverseScalingUsage(usage, ctx)
+
+	// 验证：缩放后按 Anthropic 价算 cost ≈ target
+	pIn, pOut, pCC, pCR := 5.0, 25.0, 6.25, 0.5
+	cost := float64(scaled.InputTokens)*pIn/1e6 +
+		float64(scaled.OutputTokens)*pOut/1e6 +
+		float64(scaled.CacheCreationInputTokens)*pCC/1e6 +
+		float64(scaled.CacheReadInputTokens)*pCR/1e6
+	target := usage.KiroCredits * ctx.ReverseScalingTargetUSD
+	require.InDelta(t, target, cost, target*0.01, "scaled cost should match target within 1%%")
+
+	// 4 字段比例保持
+	require.True(t, scaled.InputTokens < usage.InputTokens, "input should be scaled down")
+	require.True(t, scaled.CacheReadInputTokens < usage.CacheReadInputTokens, "cache_read should be scaled down")
+}
+
+// TestApplyKiroReverseScalingUsage_DisabledNoChange 验证 TargetUSD=0 时不缩放。
+func TestApplyKiroReverseScalingUsage_DisabledNoChange(t *testing.T) {
+	orig := Usage{
+		InputTokens:          1000,
+		OutputTokens:         100,
+		CacheReadInputTokens: 500,
+		KiroCredits:          5.0,
+	}
+	scaled := applyKiroReverseScalingUsage(orig, KiroRequestContext{
+		ReverseScalingTargetUSD: 0,
+		ReverseScalingPrices:    [4]float64{5.0, 25.0, 6.25, 0.5},
+	})
+	require.Equal(t, orig.InputTokens, scaled.InputTokens)
+	require.Equal(t, orig.OutputTokens, scaled.OutputTokens)
+	require.Equal(t, orig.CacheReadInputTokens, scaled.CacheReadInputTokens)
+}
+
+// TestApplyKiroReverseScalingUsage_NoCredits 验证 KiroCredits=0 时不缩放。
+func TestApplyKiroReverseScalingUsage_NoCredits(t *testing.T) {
+	orig := Usage{
+		InputTokens:  1000,
+		OutputTokens: 100,
+		KiroCredits:  0,
+	}
+	scaled := applyKiroReverseScalingUsage(orig, KiroRequestContext{
+		ReverseScalingTargetUSD: 0.1122,
+		ReverseScalingPrices:    [4]float64{5.0, 25.0, 6.25, 0.5},
+	})
+	require.Equal(t, orig.InputTokens, scaled.InputTokens)
+	require.Equal(t, orig.OutputTokens, scaled.OutputTokens)
+}
+
+// TestApplyKiroReverseScalingUsage_KOutOfRange 验证 K 超出 [0.1, 5] 范围时
+// 不缩放（防止上游异常导致计费失真）。
+func TestApplyKiroReverseScalingUsage_KOutOfRange(t *testing.T) {
+	// 极小 token + 极大 credits → K 会非常大
+	orig := Usage{
+		InputTokens:          1000,
+		CacheReadInputTokens: 500,
+		KiroCredits:          1000000, // 极端值
+	}
+	scaled := applyKiroReverseScalingUsage(orig, KiroRequestContext{
+		ReverseScalingTargetUSD: 0.1122,
+		ReverseScalingPrices:    [4]float64{5.0, 25.0, 6.25, 0.5},
+	})
+	// K 异常时应该退回原值
+	require.Equal(t, orig.InputTokens, scaled.InputTokens)
+	require.Equal(t, orig.CacheReadInputTokens, scaled.CacheReadInputTokens)
+}
+
+// TestApplyKiroReverseScalingUsage_ZeroTokensReturnsOriginal 验证全 0 token 时
+// （origCost=0 防除 0）退回原值。
+func TestApplyKiroReverseScalingUsage_ZeroTokensReturnsOriginal(t *testing.T) {
+	orig := Usage{KiroCredits: 5.0}
+	scaled := applyKiroReverseScalingUsage(orig, KiroRequestContext{
+		ReverseScalingTargetUSD: 0.1122,
+		ReverseScalingPrices:    [4]float64{5.0, 25.0, 6.25, 0.5},
+	})
+	require.Equal(t, orig, scaled)
+}
+
+// TestBuildKiroClaudeUsageMap_NoInternalCreditsField 验证非流式响应体的 usage
+// 不携带 _sub2api_kiro_credits（非流式计费走 ParseResult.Usage 返回值，
+// 响应体原样发给客户端，不得包含内部字段）。
+func TestBuildKiroClaudeUsageMap_NoInternalCreditsField(t *testing.T) {
+	usageMap := buildKiroClaudeUsageMap(Usage{
+		InputTokens:          100,
+		OutputTokens:         50,
+		CacheReadInputTokens: 30,
+		KiroCredits:          1.25,
+	})
+	_, exists := usageMap["_sub2api_kiro_credits"]
+	require.False(t, exists, "non-streaming usage map must not expose internal credits field")
+	require.Equal(t, 100, usageMap["input_tokens"])
+}

--- a/backend/internal/pkg/kiro/translator_test.go
+++ b/backend/internal/pkg/kiro/translator_test.go
@@ -2050,7 +2050,7 @@ func TestApplyKiroReverseScalingUsage_NoCredits(t *testing.T) {
 		KiroCredits:  0,
 	}
 	scaled := applyKiroReverseScalingUsage(orig, KiroRequestContext{
-		ReverseScalingTargetUSD: 0.1122,
+		ReverseScalingTargetUSD: 0.04,
 		ReverseScalingPrices:    [4]float64{5.0, 25.0, 6.25, 0.5},
 	})
 	require.Equal(t, orig.InputTokens, scaled.InputTokens)
@@ -2067,7 +2067,7 @@ func TestApplyKiroReverseScalingUsage_KOutOfRange(t *testing.T) {
 		KiroCredits:          1000000, // 极端值
 	}
 	scaled := applyKiroReverseScalingUsage(orig, KiroRequestContext{
-		ReverseScalingTargetUSD: 0.1122,
+		ReverseScalingTargetUSD: 0.04,
 		ReverseScalingPrices:    [4]float64{5.0, 25.0, 6.25, 0.5},
 	})
 	// K 异常时应该退回原值
@@ -2080,7 +2080,7 @@ func TestApplyKiroReverseScalingUsage_KOutOfRange(t *testing.T) {
 func TestApplyKiroReverseScalingUsage_ZeroTokensReturnsOriginal(t *testing.T) {
 	orig := Usage{KiroCredits: 5.0}
 	scaled := applyKiroReverseScalingUsage(orig, KiroRequestContext{
-		ReverseScalingTargetUSD: 0.1122,
+		ReverseScalingTargetUSD: 0.04,
 		ReverseScalingPrices:    [4]float64{5.0, 25.0, 6.25, 0.5},
 	})
 	require.Equal(t, orig, scaled)

--- a/backend/internal/pkg/kiro/websearch_credits_test.go
+++ b/backend/internal/pkg/kiro/websearch_credits_test.go
@@ -1,0 +1,87 @@
+package kiro
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// chunk 构造一个 message_delta SSE chunk，usage 里带 _sub2api_kiro_credits。
+func messageDeltaChunk(credits float64) []byte {
+	usage := map[string]any{
+		"input_tokens":            1,
+		"output_tokens":           10,
+		"cache_read_input_tokens": 100,
+	}
+	if credits > 0 {
+		usage["_sub2api_kiro_credits"] = credits
+	}
+	event := map[string]any{
+		"type":  "message_delta",
+		"delta": map[string]any{"stop_reason": "end_turn"},
+		"usage": usage,
+	}
+	b, _ := json.Marshal(event)
+	return []byte("event: message_delta\ndata: " + string(b) + "\n\n")
+}
+
+func creditsInChunk(t *testing.T, chunk []byte) (float64, bool) {
+	t.Helper()
+	for _, line := range strings.Split(string(chunk), "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var ev map[string]any
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &ev); err != nil {
+			continue
+		}
+		usage, ok := ev["usage"].(map[string]any)
+		if !ok {
+			continue
+		}
+		v, has := usage["_sub2api_kiro_credits"]
+		if !has {
+			return 0, false
+		}
+		f, _ := v.(float64)
+		return f, true
+	}
+	return 0, false
+}
+
+// TestRewriteFinalKiroCredits_OverwritesTotal 验证最终 message_delta 的 credits
+// 被覆写为累计总额。
+func TestRewriteFinalKiroCredits_OverwritesTotal(t *testing.T) {
+	chunks := [][]byte{
+		[]byte("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0}\n\n"),
+		messageDeltaChunk(1.5), // 最后一轮本身只带 1.5
+	}
+	out := RewriteFinalKiroCredits(chunks, 4.2) // 累计总额 4.2
+	got, has := creditsInChunk(t, out[1])
+	if !has {
+		t.Fatal("message_delta 应保留 _sub2api_kiro_credits 字段")
+	}
+	if got != 4.2 {
+		t.Fatalf("credits 应被覆写为累计总额 4.2，实际 %v", got)
+	}
+}
+
+// TestRewriteFinalKiroCredits_ZeroTotalNoChange 验证 totalCredits<=0 时不改动。
+func TestRewriteFinalKiroCredits_ZeroTotalNoChange(t *testing.T) {
+	chunks := [][]byte{messageDeltaChunk(1.5)}
+	out := RewriteFinalKiroCredits(chunks, 0)
+	got, has := creditsInChunk(t, out[0])
+	if !has || got != 1.5 {
+		t.Fatalf("totalCredits=0 时应保持原值 1.5，实际 has=%v got=%v", has, got)
+	}
+}
+
+// TestRewriteFinalKiroCredits_NoCreditsFieldUntouched 验证不带内部 credits 字段的
+// message_delta（非 PRO 路径）不会被注入。
+func TestRewriteFinalKiroCredits_NoCreditsFieldUntouched(t *testing.T) {
+	chunks := [][]byte{messageDeltaChunk(0)} // 不带 _sub2api_kiro_credits
+	out := RewriteFinalKiroCredits(chunks, 4.2)
+	if _, has := creditsInChunk(t, out[0]); has {
+		t.Fatal("原本不带内部 credits 字段的 message_delta 不应被注入")
+	}
+}

--- a/backend/internal/pkg/kiro/websearch_credits_test.go
+++ b/backend/internal/pkg/kiro/websearch_credits_test.go
@@ -76,12 +76,16 @@ func TestRewriteFinalKiroCredits_ZeroTotalNoChange(t *testing.T) {
 	}
 }
 
-// TestRewriteFinalKiroCredits_NoCreditsFieldUntouched 验证不带内部 credits 字段的
-// message_delta（非 PRO 路径）不会被注入。
-func TestRewriteFinalKiroCredits_NoCreditsFieldUntouched(t *testing.T) {
-	chunks := [][]byte{messageDeltaChunk(0)} // 不带 _sub2api_kiro_credits
-	out := RewriteFinalKiroCredits(chunks, 4.2)
-	if _, has := creditsInChunk(t, out[0]); has {
-		t.Fatal("原本不带内部 credits 字段的 message_delta 不应被注入")
+// TestRewriteFinalKiroCredits_InjectsWhenMissing 验证最后一轮无 metering（message_delta
+// 不带 _sub2api_kiro_credits）时，累计总额仍被注入，避免漏计费。
+func TestRewriteFinalKiroCredits_InjectsWhenMissing(t *testing.T) {
+	chunks := [][]byte{messageDeltaChunk(0)} // 最后一轮 0 credits，不带字段
+	out := RewriteFinalKiroCredits(chunks, 4.2) // 但前几轮累计 4.2
+	got, has := creditsInChunk(t, out[0])
+	if !has {
+		t.Fatal("缺字段时应注入累计 credits，避免漏计费")
+	}
+	if got != 4.2 {
+		t.Fatalf("应注入累计总额 4.2，实际 %v", got)
 	}
 }

--- a/backend/internal/pkg/kiro/websearch_stream.go
+++ b/backend/internal/pkg/kiro/websearch_stream.go
@@ -180,10 +180,13 @@ func AdjustSSEChunk(chunk []byte, offset int) ([]byte, bool) {
 }
 
 // RewriteFinalKiroCredits 把缓冲 chunks 里 message_delta 事件的
-// usage._sub2api_kiro_credits 覆写为 totalCredits。多轮 web search 时每轮都会
-// 产生一个 message_delta（只有最后一轮会转发给客户端/计费层），但每个 message_delta
-// 只带本轮 credits；本函数在最后一轮转发前把它替换成所有轮次的累计总额，
-// 确保 gateway 捕获到的 kiro_credits 是全部轮次之和而非仅最后一轮。
+// usage._sub2api_kiro_credits 设为 totalCredits（所有轮次累计总额）。多轮 web search 时
+// 每轮都会产生一个 message_delta（只有最后一轮会转发给客户端/计费层），但每个 message_delta
+// 只带本轮 credits；本函数在最后一轮转发前把它替换成累计总额，确保 gateway 捕获到的
+// kiro_credits 是全部轮次之和而非仅最后一轮。
+// 注意：本函数仅在 totalCredits>0（Kiro PRO 路径）时被调用，故对带 usage 的 message_delta
+// 一律**注入或覆写**该字段——若最后一轮无 metering 帧（本轮 credits=0）导致 message_delta
+// 缺该字段，仍要把前几轮累计的总额注入进去，否则计费层捕获到 0 → 漏计费。
 // totalCredits<=0 时原样返回（无 Kiro credits 场景，如非 PRO 账号）。
 func RewriteFinalKiroCredits(chunks [][]byte, totalCredits float64) [][]byte {
 	if totalCredits <= 0 {
@@ -211,10 +214,7 @@ func RewriteFinalKiroCredits(chunks [][]byte, totalCredits float64) [][]byte {
 			if !ok {
 				continue
 			}
-			// 只覆写已经携带内部 credits 字段的 message_delta（即 Kiro PRO 反向缩放路径）。
-			if _, has := usage["_sub2api_kiro_credits"]; !has {
-				continue
-			}
+			// 注入或覆写为累计总额（缺字段时注入，避免最后一轮零 credits 导致累计丢失）。
 			usage["_sub2api_kiro_credits"] = totalCredits
 			rewritten, err := json.Marshal(event)
 			if err != nil {

--- a/backend/internal/pkg/kiro/websearch_stream.go
+++ b/backend/internal/pkg/kiro/websearch_stream.go
@@ -179,6 +179,57 @@ func AdjustSSEChunk(chunk []byte, offset int) ([]byte, bool) {
 	return filterSSEChunk(chunk, -1, offset)
 }
 
+// RewriteFinalKiroCredits 把缓冲 chunks 里 message_delta 事件的
+// usage._sub2api_kiro_credits 覆写为 totalCredits。多轮 web search 时每轮都会
+// 产生一个 message_delta（只有最后一轮会转发给客户端/计费层），但每个 message_delta
+// 只带本轮 credits；本函数在最后一轮转发前把它替换成所有轮次的累计总额，
+// 确保 gateway 捕获到的 kiro_credits 是全部轮次之和而非仅最后一轮。
+// totalCredits<=0 时原样返回（无 Kiro credits 场景，如非 PRO 账号）。
+func RewriteFinalKiroCredits(chunks [][]byte, totalCredits float64) [][]byte {
+	if totalCredits <= 0 {
+		return chunks
+	}
+	for ci, chunk := range chunks {
+		lines := strings.Split(string(chunk), "\n")
+		changed := false
+		for li, line := range lines {
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			payload := strings.TrimSpace(strings.TrimPrefix(line, "data: "))
+			if payload == "" || payload == "[DONE]" {
+				continue
+			}
+			var event map[string]any
+			if err := json.Unmarshal([]byte(payload), &event); err != nil {
+				continue
+			}
+			if eventType, _ := event["type"].(string); eventType != "message_delta" {
+				continue
+			}
+			usage, ok := event["usage"].(map[string]any)
+			if !ok {
+				continue
+			}
+			// 只覆写已经携带内部 credits 字段的 message_delta（即 Kiro PRO 反向缩放路径）。
+			if _, has := usage["_sub2api_kiro_credits"]; !has {
+				continue
+			}
+			usage["_sub2api_kiro_credits"] = totalCredits
+			rewritten, err := json.Marshal(event)
+			if err != nil {
+				continue
+			}
+			lines[li] = "data: " + string(rewritten)
+			changed = true
+		}
+		if changed {
+			chunks[ci] = []byte(strings.Join(lines, "\n"))
+		}
+	}
+	return chunks
+}
+
 func MaxContentBlockIndex(chunks [][]byte) int {
 	maxIndex := -1
 	for _, chunk := range chunks {

--- a/backend/internal/repository/api_key_repo.go
+++ b/backend/internal/repository/api_key_repo.go
@@ -819,6 +819,7 @@ func groupEntityToService(g *dbent.Group) *service.Group {
 		KiroStickySessionTTLSeconds:     g.KiroStickySessionTTLSeconds,
 		KiroCacheEmulationRatio:         g.KiroCacheEmulationRatio,
 		KiroCreditTargetUSD:             g.KiroCreditTargetUsd,
+		KiroCacheForceRatioCenter:       g.KiroCacheForceRatioCenter,
 		CreatedAt:                       g.CreatedAt,
 		UpdatedAt:                       g.UpdatedAt,
 	}

--- a/backend/internal/repository/api_key_repo.go
+++ b/backend/internal/repository/api_key_repo.go
@@ -818,6 +818,7 @@ func groupEntityToService(g *dbent.Group) *service.Group {
 		KiroAutoStickyEnabled:           g.KiroAutoStickyEnabled,
 		KiroStickySessionTTLSeconds:     g.KiroStickySessionTTLSeconds,
 		KiroCacheEmulationRatio:         g.KiroCacheEmulationRatio,
+		KiroCreditTargetUSD:             g.KiroCreditTargetUsd,
 		CreatedAt:                       g.CreatedAt,
 		UpdatedAt:                       g.UpdatedAt,
 	}

--- a/backend/internal/repository/group_repo.go
+++ b/backend/internal/repository/group_repo.go
@@ -72,7 +72,8 @@ func (r *groupRepository) Create(ctx context.Context, groupIn *service.Group) er
 		SetKiroCacheEmulationEnabled(groupIn.KiroCacheEmulationEnabled).
 		SetKiroAutoStickyEnabled(groupIn.KiroAutoStickyEnabled).
 		SetKiroStickySessionTTLSeconds(groupIn.KiroStickySessionTTLSeconds).
-		SetKiroCacheEmulationRatio(groupIn.KiroCacheEmulationRatio)
+		SetKiroCacheEmulationRatio(groupIn.KiroCacheEmulationRatio).
+		SetKiroCreditTargetUsd(groupIn.KiroCreditTargetUSD)
 
 	// 设置模型路由配置
 	if groupIn.ModelRouting != nil {
@@ -153,7 +154,8 @@ func (r *groupRepository) Update(ctx context.Context, groupIn *service.Group) er
 		SetKiroCacheEmulationEnabled(groupIn.KiroCacheEmulationEnabled).
 		SetKiroAutoStickyEnabled(groupIn.KiroAutoStickyEnabled).
 		SetKiroStickySessionTTLSeconds(groupIn.KiroStickySessionTTLSeconds).
-		SetKiroCacheEmulationRatio(groupIn.KiroCacheEmulationRatio)
+		SetKiroCacheEmulationRatio(groupIn.KiroCacheEmulationRatio).
+		SetKiroCreditTargetUsd(groupIn.KiroCreditTargetUSD)
 
 	// 显式处理可空字段：nil 需要 clear，非 nil 需要 set。
 	if groupIn.DailyLimitUSD != nil {

--- a/backend/internal/repository/group_repo.go
+++ b/backend/internal/repository/group_repo.go
@@ -73,7 +73,8 @@ func (r *groupRepository) Create(ctx context.Context, groupIn *service.Group) er
 		SetKiroAutoStickyEnabled(groupIn.KiroAutoStickyEnabled).
 		SetKiroStickySessionTTLSeconds(groupIn.KiroStickySessionTTLSeconds).
 		SetKiroCacheEmulationRatio(groupIn.KiroCacheEmulationRatio).
-		SetKiroCreditTargetUsd(groupIn.KiroCreditTargetUSD)
+		SetKiroCreditTargetUsd(groupIn.KiroCreditTargetUSD).
+		SetKiroCacheForceRatioCenter(groupIn.KiroCacheForceRatioCenter)
 
 	// 设置模型路由配置
 	if groupIn.ModelRouting != nil {
@@ -155,7 +156,8 @@ func (r *groupRepository) Update(ctx context.Context, groupIn *service.Group) er
 		SetKiroAutoStickyEnabled(groupIn.KiroAutoStickyEnabled).
 		SetKiroStickySessionTTLSeconds(groupIn.KiroStickySessionTTLSeconds).
 		SetKiroCacheEmulationRatio(groupIn.KiroCacheEmulationRatio).
-		SetKiroCreditTargetUsd(groupIn.KiroCreditTargetUSD)
+		SetKiroCreditTargetUsd(groupIn.KiroCreditTargetUSD).
+		SetKiroCacheForceRatioCenter(groupIn.KiroCacheForceRatioCenter)
 
 	// 显式处理可空字段：nil 需要 clear，非 nil 需要 set。
 	if groupIn.DailyLimitUSD != nil {

--- a/backend/internal/repository/usage_log_repo.go
+++ b/backend/internal/repository/usage_log_repo.go
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const usageLogSelectColumns = "id, user_id, api_key_id, account_id, request_id, model, requested_model, upstream_model, group_id, subscription_id, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cache_creation_5m_tokens, cache_creation_1h_tokens, image_output_tokens, image_output_cost, input_cost, output_cost, cache_creation_cost, cache_read_cost, total_cost, actual_cost, rate_multiplier, account_rate_multiplier, billing_type, request_type, stream, openai_ws_mode, duration_ms, first_token_ms, user_agent, ip_address, image_count, image_size, image_input_size, image_output_size, image_size_source, image_size_breakdown, service_tier, reasoning_effort, inbound_endpoint, upstream_endpoint, cache_ttl_overridden, channel_id, model_mapping_chain, billing_tier, billing_mode, account_stats_cost, created_at"
+const usageLogSelectColumns = "id, user_id, api_key_id, account_id, request_id, model, requested_model, upstream_model, group_id, subscription_id, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cache_creation_5m_tokens, cache_creation_1h_tokens, kiro_credits, image_output_tokens, image_output_cost, input_cost, output_cost, cache_creation_cost, cache_read_cost, total_cost, actual_cost, rate_multiplier, account_rate_multiplier, billing_type, request_type, stream, openai_ws_mode, duration_ms, first_token_ms, user_agent, ip_address, image_count, image_size, image_input_size, image_output_size, image_size_source, image_size_breakdown, service_tier, reasoning_effort, inbound_endpoint, upstream_endpoint, cache_ttl_overridden, channel_id, model_mapping_chain, billing_tier, billing_mode, account_stats_cost, created_at"
 
 // usageLogInsertArgTypes must stay in the same order as:
 //  1. prepareUsageLogInsert().args
@@ -55,6 +55,7 @@ var usageLogInsertArgTypes = [...]string{
 	"integer",     // cache_read_tokens
 	"integer",     // cache_creation_5m_tokens
 	"integer",     // cache_creation_1h_tokens
+	"numeric",     // kiro_credits
 	"integer",     // image_output_tokens
 	"numeric",     // image_output_cost
 	"numeric",     // input_cost
@@ -372,6 +373,7 @@ func (r *usageLogRepository) createSingle(ctx context.Context, sqlq sqlExecutor,
 			cache_read_tokens,
 			cache_creation_5m_tokens,
 			cache_creation_1h_tokens,
+			kiro_credits,
 			image_output_tokens,
 			image_output_cost,
 			input_cost,
@@ -413,7 +415,7 @@ func (r *usageLogRepository) createSingle(ctx context.Context, sqlq sqlExecutor,
 			$10, $11, $12, $13,
 			$14, $15, $16, $17,
 			$18, $19, $20, $21, $22, $23,
-			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50
+			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51
 		)
 		ON CONFLICT (request_id, api_key_id) DO NOTHING
 		RETURNING id, created_at
@@ -814,6 +816,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 			cache_read_tokens,
 			cache_creation_5m_tokens,
 			cache_creation_1h_tokens,
+			kiro_credits,
 			image_output_tokens,
 			image_output_cost,
 			input_cost,
@@ -895,6 +898,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 				cache_read_tokens,
 				cache_creation_5m_tokens,
 				cache_creation_1h_tokens,
+				kiro_credits,
 				image_output_tokens,
 				image_output_cost,
 				input_cost,
@@ -947,6 +951,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 				cache_read_tokens,
 				cache_creation_5m_tokens,
 				cache_creation_1h_tokens,
+				kiro_credits,
 				image_output_tokens,
 				image_output_cost,
 				input_cost,
@@ -1039,6 +1044,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			cache_read_tokens,
 			cache_creation_5m_tokens,
 			cache_creation_1h_tokens,
+			kiro_credits,
 			image_output_tokens,
 			image_output_cost,
 			input_cost,
@@ -1117,6 +1123,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			cache_read_tokens,
 			cache_creation_5m_tokens,
 			cache_creation_1h_tokens,
+			kiro_credits,
 			image_output_tokens,
 			image_output_cost,
 			input_cost,
@@ -1169,6 +1176,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			cache_read_tokens,
 			cache_creation_5m_tokens,
 			cache_creation_1h_tokens,
+			kiro_credits,
 			image_output_tokens,
 			image_output_cost,
 			input_cost,
@@ -1229,6 +1237,7 @@ func execUsageLogInsertNoResult(ctx context.Context, sqlq sqlExecutor, prepared 
 			cache_read_tokens,
 			cache_creation_5m_tokens,
 			cache_creation_1h_tokens,
+			kiro_credits,
 			image_output_tokens,
 			image_output_cost,
 			input_cost,
@@ -1270,7 +1279,7 @@ func execUsageLogInsertNoResult(ctx context.Context, sqlq sqlExecutor, prepared 
 			$10, $11, $12, $13,
 			$14, $15, $16, $17,
 			$18, $19, $20, $21, $22, $23,
-			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50
+			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51
 		)
 		ON CONFLICT (request_id, api_key_id) DO NOTHING
 	`, prepared.args...)
@@ -1341,6 +1350,7 @@ func prepareUsageLogInsert(log *service.UsageLog) usageLogInsertPrepared {
 			log.CacheReadTokens,
 			log.CacheCreation5mTokens,
 			log.CacheCreation1hTokens,
+			log.KiroCredits,
 			log.ImageOutputTokens,
 			log.ImageOutputCost,
 			log.InputCost,
@@ -4265,6 +4275,7 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		cacheReadTokens       int
 		cacheCreation5m       int
 		cacheCreation1h       int
+		kiroCredits           sql.NullFloat64
 		imageOutputTokens     int
 		imageOutputCost       float64
 		inputCost             float64
@@ -4319,6 +4330,7 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		&cacheReadTokens,
 		&cacheCreation5m,
 		&cacheCreation1h,
+		&kiroCredits,
 		&imageOutputTokens,
 		&imageOutputCost,
 		&inputCost,
@@ -4371,6 +4383,13 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		CacheReadTokens:       cacheReadTokens,
 		CacheCreation5mTokens: cacheCreation5m,
 		CacheCreation1hTokens: cacheCreation1h,
+		KiroCredits: func() *float64 {
+			if kiroCredits.Valid {
+				v := kiroCredits.Float64
+				return &v
+			}
+			return nil
+		}(),
 		ImageOutputTokens:     imageOutputTokens,
 		ImageOutputCost:       imageOutputCost,
 		InputCost:             inputCost,

--- a/backend/internal/repository/usage_log_repo_request_type_test.go
+++ b/backend/internal/repository/usage_log_repo_request_type_test.go
@@ -56,6 +56,7 @@ func TestUsageLogRepositoryCreateSyncRequestTypeAndLegacyFields(t *testing.T) {
 			log.CacheReadTokens,
 			log.CacheCreation5mTokens,
 			log.CacheCreation1hTokens,
+			sqlmock.AnyArg(), // kiro_credits
 			log.ImageOutputTokens,
 			log.ImageOutputCost,
 			log.InputCost,
@@ -139,6 +140,7 @@ func TestUsageLogRepositoryCreate_PersistsServiceTier(t *testing.T) {
 			log.CacheReadTokens,
 			log.CacheCreation5mTokens,
 			log.CacheCreation1hTokens,
+			sqlmock.AnyArg(), // kiro_credits
 			log.ImageOutputTokens,
 			log.ImageOutputCost,
 			log.InputCost,
@@ -259,11 +261,11 @@ func TestPrepareUsageLogInsert_PersistsImageSizeMetadata(t *testing.T) {
 		CreatedAt:          time.Date(2025, 1, 6, 12, 0, 0, 0, time.UTC),
 	})
 
-	require.Equal(t, sql.NullString{String: imageSize, Valid: true}, prepared.args[34])
-	require.Equal(t, sql.NullString{String: inputSize, Valid: true}, prepared.args[35])
-	require.Equal(t, sql.NullString{String: outputSize, Valid: true}, prepared.args[36])
-	require.Equal(t, sql.NullString{String: source, Valid: true}, prepared.args[37])
-	breakdownJSON, ok := prepared.args[38].(string)
+	require.Equal(t, sql.NullString{String: imageSize, Valid: true}, prepared.args[35])
+	require.Equal(t, sql.NullString{String: inputSize, Valid: true}, prepared.args[36])
+	require.Equal(t, sql.NullString{String: outputSize, Valid: true}, prepared.args[37])
+	require.Equal(t, sql.NullString{String: source, Valid: true}, prepared.args[38])
+	breakdownJSON, ok := prepared.args[39].(string)
 	require.True(t, ok)
 	require.JSONEq(t, `{"1K":1,"4K":1}`, breakdownJSON)
 }
@@ -612,6 +614,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullInt64{},
 			sql.NullInt64{},
 			0, 0, 0, 0, 0, 0,
+			sql.NullFloat64{}, // kiro_credits
 			0, 0.0, // image_output_tokens, image_output_cost
 			0.0, 0.0, 0.0, 0.0, 0.8, 0.8,
 			1.0,
@@ -674,6 +677,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			4,                 // cache_read_tokens
 			5,                 // cache_creation_5m_tokens
 			6,                 // cache_creation_1h_tokens
+			sql.NullFloat64{}, // kiro_credits
 			0,                 // image_output_tokens
 			0.0,               // image_output_cost
 			0.1,               // input_cost
@@ -732,6 +736,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullInt64{},
 			sql.NullInt64{},
 			1, 2, 3, 4, 5, 6,
+			sql.NullFloat64{}, // kiro_credits
 			0, 0.0, // image_output_tokens, image_output_cost
 			0.1, 0.2, 0.3, 0.4, 1.0, 0.9,
 			1.0,
@@ -784,6 +789,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullInt64{},
 			sql.NullInt64{},
 			1, 2, 3, 4, 5, 6,
+			sql.NullFloat64{}, // kiro_credits
 			0, 0.0, // image_output_tokens, image_output_cost
 			0.1, 0.2, 0.3, 0.4, 1.0, 0.9,
 			1.0,

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -367,6 +367,7 @@ func TestAPIContracts(t *testing.T) {
 						"kiro_sticky_session_ttl_seconds": 0,
 						"kiro_cache_emulation_enabled": false,
 						"kiro_cache_emulation_ratio": 0,
+						"kiro_credit_target_usd": 0,
 						"created_at": "2025-01-02T03:04:05Z",
 						"updated_at": "2025-01-02T03:04:05Z"
 					}

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -236,7 +236,8 @@ type CreateGroupInput struct {
 	KiroStickySessionTTLSeconds *int
 	KiroCacheEmulationRatio     *float64
 	// Kiro 反向 token 缩放：每 credit 对应 USD 余额（0=禁用，仅 platform=kiro 生效）
-	KiroCreditTargetUSD *float64
+	KiroCreditTargetUSD       *float64
+	KiroCacheForceRatioCenter *float64
 	// 从指定分组复制账号（创建分组后在同一事务内绑定）
 	CopyAccountsFromGroupIDs []int64
 }
@@ -284,7 +285,8 @@ type UpdateGroupInput struct {
 	KiroStickySessionTTLSeconds *int
 	KiroCacheEmulationRatio     *float64
 	// Kiro 反向 token 缩放：每 credit 对应 USD 余额（仅 platform=kiro 生效）
-	KiroCreditTargetUSD *float64
+	KiroCreditTargetUSD       *float64
+	KiroCacheForceRatioCenter *float64
 	// 从指定分组复制账号（同步操作：先清空当前分组的账号绑定，再绑定源分组的账号）
 	CopyAccountsFromGroupIDs []int64
 }
@@ -1937,9 +1939,13 @@ func (s *adminServiceImpl) CreateGroup(ctx context.Context, input *CreateGroupIn
 	if input.KiroCreditTargetUSD != nil {
 		group.KiroCreditTargetUSD = *input.KiroCreditTargetUSD
 	}
+	if input.KiroCacheForceRatioCenter != nil {
+		group.KiroCacheForceRatioCenter = *input.KiroCacheForceRatioCenter
+	}
 	sanitizeGroupMessagesDispatchFields(group)
 	normalizeKiroCacheEmulationFields(group)
 	normalizeKiroCreditTargetFields(group)
+	normalizeKiroCacheForceFields(group)
 	if err := s.groupRepo.Create(ctx, group); err != nil {
 		return nil, err
 	}
@@ -2205,9 +2211,13 @@ func (s *adminServiceImpl) UpdateGroup(ctx context.Context, id int64, input *Upd
 	if input.KiroCreditTargetUSD != nil {
 		group.KiroCreditTargetUSD = *input.KiroCreditTargetUSD
 	}
+	if input.KiroCacheForceRatioCenter != nil {
+		group.KiroCacheForceRatioCenter = *input.KiroCacheForceRatioCenter
+	}
 	sanitizeGroupMessagesDispatchFields(group)
 	normalizeKiroCacheEmulationFields(group)
 	normalizeKiroCreditTargetFields(group)
+	normalizeKiroCacheForceFields(group)
 
 	if err := s.groupRepo.Update(ctx, group); err != nil {
 		return nil, err

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -235,6 +235,8 @@ type CreateGroupInput struct {
 	KiroAutoStickyEnabled       *bool
 	KiroStickySessionTTLSeconds *int
 	KiroCacheEmulationRatio     *float64
+	// Kiro 反向 token 缩放：每 credit 对应 USD 余额（0=禁用，仅 platform=kiro 生效）
+	KiroCreditTargetUSD *float64
 	// 从指定分组复制账号（创建分组后在同一事务内绑定）
 	CopyAccountsFromGroupIDs []int64
 }
@@ -281,6 +283,8 @@ type UpdateGroupInput struct {
 	KiroAutoStickyEnabled       *bool
 	KiroStickySessionTTLSeconds *int
 	KiroCacheEmulationRatio     *float64
+	// Kiro 反向 token 缩放：每 credit 对应 USD 余额（仅 platform=kiro 生效）
+	KiroCreditTargetUSD *float64
 	// 从指定分组复制账号（同步操作：先清空当前分组的账号绑定，再绑定源分组的账号）
 	CopyAccountsFromGroupIDs []int64
 }
@@ -1930,8 +1934,12 @@ func (s *adminServiceImpl) CreateGroup(ctx context.Context, input *CreateGroupIn
 	if input.KiroCacheEmulationRatio != nil {
 		group.KiroCacheEmulationRatio = *input.KiroCacheEmulationRatio
 	}
+	if input.KiroCreditTargetUSD != nil {
+		group.KiroCreditTargetUSD = *input.KiroCreditTargetUSD
+	}
 	sanitizeGroupMessagesDispatchFields(group)
 	normalizeKiroCacheEmulationFields(group)
+	normalizeKiroCreditTargetFields(group)
 	if err := s.groupRepo.Create(ctx, group); err != nil {
 		return nil, err
 	}
@@ -2194,8 +2202,12 @@ func (s *adminServiceImpl) UpdateGroup(ctx context.Context, id int64, input *Upd
 	if input.KiroCacheEmulationRatio != nil {
 		group.KiroCacheEmulationRatio = *input.KiroCacheEmulationRatio
 	}
+	if input.KiroCreditTargetUSD != nil {
+		group.KiroCreditTargetUSD = *input.KiroCreditTargetUSD
+	}
 	sanitizeGroupMessagesDispatchFields(group)
 	normalizeKiroCacheEmulationFields(group)
+	normalizeKiroCreditTargetFields(group)
 
 	if err := s.groupRepo.Update(ctx, group); err != nil {
 		return nil, err

--- a/backend/internal/service/api_key_auth_cache.go
+++ b/backend/internal/service/api_key_auth_cache.go
@@ -101,7 +101,8 @@ type APIKeyAuthGroupSnapshot struct {
 	KiroCacheEmulationRatio     float64 `json:"kiro_cache_emulation_ratio"`
 
 	// Kiro 反向 token 缩放锚定单价（仅 platform=kiro 生效；0 = 禁用）
-	KiroCreditTargetUSD float64 `json:"kiro_credit_target_usd"`
+	KiroCreditTargetUSD       float64 `json:"kiro_credit_target_usd"`
+	KiroCacheForceRatioCenter float64 `json:"kiro_cache_force_ratio_center"`
 }
 
 // APIKeyAuthCacheEntry 缓存条目，支持负缓存

--- a/backend/internal/service/api_key_auth_cache.go
+++ b/backend/internal/service/api_key_auth_cache.go
@@ -99,6 +99,9 @@ type APIKeyAuthGroupSnapshot struct {
 	KiroAutoStickyEnabled       bool    `json:"kiro_auto_sticky_enabled"`
 	KiroStickySessionTTLSeconds int     `json:"kiro_sticky_session_ttl_seconds"`
 	KiroCacheEmulationRatio     float64 `json:"kiro_cache_emulation_ratio"`
+
+	// Kiro 反向 token 缩放锚定单价（仅 platform=kiro 生效；0 = 禁用）
+	KiroCreditTargetUSD float64 `json:"kiro_credit_target_usd"`
 }
 
 // APIKeyAuthCacheEntry 缓存条目，支持负缓存

--- a/backend/internal/service/api_key_auth_cache_impl.go
+++ b/backend/internal/service/api_key_auth_cache_impl.go
@@ -14,7 +14,7 @@ import (
 	"github.com/dgraph-io/ristretto"
 )
 
-const apiKeyAuthSnapshotVersion = 14 // v14: add Kiro credit target USD for group snapshot (reverse token scaling anchor price); v13: Kiro auto sticky routing switch
+const apiKeyAuthSnapshotVersion = 15 // v15: Kiro credit target USD + cache force ratio center in group snapshot
 
 type apiKeyAuthCacheConfig struct {
 	l1Size        int
@@ -287,6 +287,7 @@ func (s *APIKeyService) snapshotFromAPIKey(ctx context.Context, apiKey *APIKey) 
 			KiroStickySessionTTLSeconds:     groupForSnapshot.EffectiveKiroStickySessionTTLSeconds(),
 			KiroCacheEmulationRatio:         groupForSnapshot.EffectiveKiroCacheEmulationRatio(),
 			KiroCreditTargetUSD:             groupForSnapshot.EffectiveKiroCreditTargetUSD(),
+			KiroCacheForceRatioCenter:       groupForSnapshot.EffectiveKiroCacheForceRatioCenter(),
 		}
 	}
 	return snapshot
@@ -365,9 +366,11 @@ func (s *APIKeyService) snapshotToAPIKey(key string, snapshot *APIKeyAuthSnapsho
 			KiroStickySessionTTLSeconds:     snapshot.Group.KiroStickySessionTTLSeconds,
 			KiroCacheEmulationRatio:         snapshot.Group.KiroCacheEmulationRatio,
 			KiroCreditTargetUSD:             snapshot.Group.KiroCreditTargetUSD,
+			KiroCacheForceRatioCenter:       snapshot.Group.KiroCacheForceRatioCenter,
 		}
 		normalizeKiroCacheEmulationFields(apiKey.Group)
 		normalizeKiroCreditTargetFields(apiKey.Group)
+		normalizeKiroCacheForceFields(apiKey.Group)
 	}
 	s.compileAPIKeyIPRules(apiKey)
 	return apiKey

--- a/backend/internal/service/api_key_auth_cache_impl.go
+++ b/backend/internal/service/api_key_auth_cache_impl.go
@@ -14,7 +14,7 @@ import (
 	"github.com/dgraph-io/ristretto"
 )
 
-const apiKeyAuthSnapshotVersion = 13 // v13: reload snapshots for Kiro auto sticky routing switch
+const apiKeyAuthSnapshotVersion = 14 // v14: add Kiro credit target USD for group snapshot (reverse token scaling anchor price); v13: Kiro auto sticky routing switch
 
 type apiKeyAuthCacheConfig struct {
 	l1Size        int
@@ -286,6 +286,7 @@ func (s *APIKeyService) snapshotFromAPIKey(ctx context.Context, apiKey *APIKey) 
 			KiroAutoStickyEnabled:           groupForSnapshot.EffectiveKiroAutoStickyEnabled(),
 			KiroStickySessionTTLSeconds:     groupForSnapshot.EffectiveKiroStickySessionTTLSeconds(),
 			KiroCacheEmulationRatio:         groupForSnapshot.EffectiveKiroCacheEmulationRatio(),
+			KiroCreditTargetUSD:             groupForSnapshot.EffectiveKiroCreditTargetUSD(),
 		}
 	}
 	return snapshot
@@ -363,8 +364,10 @@ func (s *APIKeyService) snapshotToAPIKey(key string, snapshot *APIKeyAuthSnapsho
 			KiroAutoStickyEnabled:           snapshot.Group.KiroAutoStickyEnabled,
 			KiroStickySessionTTLSeconds:     snapshot.Group.KiroStickySessionTTLSeconds,
 			KiroCacheEmulationRatio:         snapshot.Group.KiroCacheEmulationRatio,
+			KiroCreditTargetUSD:             snapshot.Group.KiroCreditTargetUSD,
 		}
 		normalizeKiroCacheEmulationFields(apiKey.Group)
+		normalizeKiroCreditTargetFields(apiKey.Group)
 	}
 	s.compileAPIKeyIPRules(apiKey)
 	return apiKey

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -9260,6 +9260,35 @@ type recordUsageCoreInput struct {
 
 // recordUsageCore 是 RecordUsage 和 RecordUsageWithLongContext 的统一实现。
 // LongContextThreshold > 0 时 Token 计费回退走 CalculateCostWithLongContext。
+// applyKiroCreditDirectCost 把成本覆写为 Kiro credits × target_usd。
+// Kiro PRO 账号按 credits 计费，kiro_credit_target_usd 语义为"每 credit 最终扣费 USD"，
+// 是最终价，不再叠加 group/user rate multiplier 或 channel pricing。
+// 按比例缩放各成本子项以保持 sum(子项)==TotalCost 的不变式（供展示/账号统计），
+// 再把 TotalCost 与 ActualCost 都置为 target。credits 或 targetUSD<=0 时不动。
+func applyKiroCreditDirectCost(cost *CostBreakdown, credits, targetUSD float64) {
+	if cost == nil || credits <= 0 || targetUSD <= 0 {
+		return
+	}
+	target := credits * targetUSD
+	if cost.TotalCost > 0 {
+		ratio := target / cost.TotalCost
+		cost.InputCost *= ratio
+		cost.OutputCost *= ratio
+		cost.ImageOutputCost *= ratio
+		cost.CacheCreationCost *= ratio
+		cost.CacheReadCost *= ratio
+	} else {
+		// 无 token 成本兜底：全部归到 input 子项，保持 sum==Total。
+		cost.InputCost = target
+		cost.OutputCost = 0
+		cost.ImageOutputCost = 0
+		cost.CacheCreationCost = 0
+		cost.CacheReadCost = 0
+	}
+	cost.TotalCost = target
+	cost.ActualCost = target
+}
+
 func (s *GatewayService) recordUsageCore(ctx context.Context, input *recordUsageCoreInput, opts *recordUsageOpts) error {
 	result := input.Result
 	apiKey := input.APIKey
@@ -9314,6 +9343,14 @@ func (s *GatewayService) recordUsageCore(ctx context.Context, input *recordUsage
 	// 计算费用
 	opts.IsKiroAccount = account != nil && account.Platform == PlatformKiro
 	cost := s.calculateRecordUsageCost(ctx, result, apiKey, billingModel, multiplier, imageMultiplier, opts)
+
+	// Kiro credit 直接计费：group 配了 kiro_credit_target_usd 时，最终扣费严格等于
+	// credits × target_usd，绕过 rate multiplier / channel pricing 的二次改写
+	// （反向缩放后的 token 仅用于展示口径，真实成本以 Kiro credits 为准）。
+	if cost != nil && opts.IsKiroAccount && apiKey.Group != nil &&
+		apiKey.Group.KiroReverseScalingEnabled() && result.Usage.KiroCredits > 0 {
+		applyKiroCreditDirectCost(cost, result.Usage.KiroCredits, apiKey.Group.EffectiveKiroCreditTargetUSD())
+	}
 
 	// 判断计费方式：订阅模式 vs 余额模式
 	isSubscriptionBilling := subscription != nil && apiKey.Group != nil && apiKey.Group.IsSubscriptionType()

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -8919,6 +8919,10 @@ func buildUsageBillingCommand(requestID string, usageLog *UsageLog, p *postUsage
 		cmd.APIKeyRateLimitCost = p.Cost.ActualCost
 	}
 	if p.shouldUpdateAccountQuota() {
+		// 账号侧配额成本用 AccountRateMultiplier（账号级独立倍率，与用户侧计费无关）。
+		// Kiro credit 直接计费已把 TotalCost 置为 credits×target_usd（最终价，已绕过
+		// group/user 倍率与渠道定价）；这里再乘的是账号侧倍率（默认 1），与普通计费
+		// "账号侧用 account 倍率、用户侧用 ActualCost" 的关系一致，非重复叠加。
 		cmd.AccountQuotaCost = p.Cost.TotalCost * p.AccountRateMultiplier
 	}
 
@@ -9265,9 +9269,18 @@ type recordUsageCoreInput struct {
 // 是最终价，不再叠加 group/user rate multiplier 或 channel pricing。
 // 按比例缩放各成本子项以保持 sum(子项)==TotalCost 的不变式（供展示/账号统计），
 // 再把 TotalCost 与 ActualCost 都置为 target。credits 或 targetUSD<=0 时不动。
+// kiroCreditsPerRequestSanityCap 是单请求 credits 的安全上限。正常单请求 credits 为
+// 个位数；远超此值视为上游 metering 异常或被篡改，clamp 并打 ALERT，避免一次请求按
+// credits×target 扣掉用户巨额余额（反向缩放路径有 K∈[0.1,5] 围栏，直接计费路径需对等防护）。
+const kiroCreditsPerRequestSanityCap = 500.0
+
 func applyKiroCreditDirectCost(cost *CostBreakdown, credits, targetUSD float64) {
 	if cost == nil || credits <= 0 || targetUSD <= 0 {
 		return
+	}
+	if credits > kiroCreditsPerRequestSanityCap {
+		logger.LegacyPrintf("service.gateway", "ALERT kiro credits over per-request sanity cap, clamped: credits=%.4f cap=%.0f target_usd=%.4f", credits, kiroCreditsPerRequestSanityCap, targetUSD)
+		credits = kiroCreditsPerRequestSanityCap
 	}
 	target := credits * targetUSD
 	if cost.TotalCost > 0 {

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -550,6 +550,10 @@ type ClaudeUsage struct {
 	CacheCreation5mTokens    int // 5分钟缓存创建token（来自嵌套 cache_creation 对象）
 	CacheCreation1hTokens    int // 1小时缓存创建token（来自嵌套 cache_creation 对象）
 	ImageOutputTokens        int `json:"image_output_tokens,omitempty"`
+
+	// KiroCredits 来自 Kiro 上游 meteringEvent.usage（仅 Kiro 平台有值）。
+	// 透传给 usage_logs.kiro_credits 字段做事后对账用。
+	KiroCredits float64 `json:"-"`
 }
 
 // ForwardResult 转发结果
@@ -5935,6 +5939,7 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 
 			if !clientDisconnected {
 				restored := string(reverseToolNamesIfPresent(c, []byte(line)))
+				restored = stripSub2apiInternalUsageFields(restored)
 				if _, err := io.WriteString(w, restored); err != nil {
 					clientDisconnected = true
 					logger.LegacyPrintf("service.gateway", "[Anthropic passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
@@ -5997,6 +6002,24 @@ func extractAnthropicSSEDataLine(line string) (string, bool) {
 	return line[start:], true
 }
 
+// stripSub2apiInternalUsageFields 从出站 SSE 行中移除 sub2api 内部 usage 字段
+// （目前只有 _sub2api_kiro_credits：translator → 计费层的内部通道），
+// 确保不透传给客户端。非匹配行零开销。
+func stripSub2apiInternalUsageFields(line string) string {
+	if !strings.Contains(line, "_sub2api_kiro_credits") {
+		return line
+	}
+	data, ok := extractAnthropicSSEDataLine(line)
+	if !ok {
+		return line
+	}
+	cleaned, err := sjson.Delete(data, "usage._sub2api_kiro_credits")
+	if err != nil {
+		return line
+	}
+	return line[:len(line)-len(data)] + cleaned
+}
+
 func (s *GatewayService) parseSSEUsagePassthrough(data string, usage *ClaudeUsage) {
 	if usage == nil || data == "" || data == "[DONE]" {
 		return
@@ -6042,6 +6065,11 @@ func (s *GatewayService) parseSSEUsagePassthrough(data string, usage *ClaudeUsag
 			}
 			if cc1h.Exists() && cc1h.Int() > 0 {
 				usage.CacheCreation1hTokens = int(cc1h.Int())
+			}
+
+			// sub2api 内部通道：Kiro 反向缩放透传 credits（仅 Kiro 平台）
+			if v := deltaUsage.Get("_sub2api_kiro_credits"); v.Exists() && v.Float() > 0 {
+				usage.KiroCredits = v.Float()
 			}
 		}
 	}
@@ -8121,6 +8149,15 @@ func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http
 		}
 
 		usagePatch := s.extractSSEUsagePatch(event)
+		// usagePatch 已捕获 _sub2api_kiro_credits（内部通道），转发客户端前剥离。
+		if eventType == "message_delta" {
+			if u, ok := event["usage"].(map[string]any); ok {
+				if _, exists := u["_sub2api_kiro_credits"]; exists {
+					delete(u, "_sub2api_kiro_credits")
+					eventChanged = true
+				}
+			}
+		}
 		if anthropicStreamEventIsTerminal(eventName, dataLine) {
 			sawTerminalEvent = true
 		}
@@ -8312,6 +8349,9 @@ type sseUsagePatch struct {
 	hasCacheCreation5m       bool
 	cacheCreation1hTokens    int
 	hasCacheCreation1h       bool
+	// Kiro 反向缩放：sub2api 内部通道，从 _sub2api_kiro_credits 解析
+	kiroCredits    float64
+	hasKiroCredits bool
 }
 
 func (s *GatewayService) extractSSEUsagePatch(event map[string]any) *sseUsagePatch {
@@ -8386,6 +8426,11 @@ func (s *GatewayService) extractSSEUsagePatch(event map[string]any) *sseUsagePat
 				patch.hasCacheCreation1h = true
 			}
 		}
+		// sub2api Kiro 反向缩放透传字段
+		if v, ok := parseSSEUsageFloat(usageObj["_sub2api_kiro_credits"]); ok && v > 0 {
+			patch.kiroCredits = v
+			patch.hasKiroCredits = true
+		}
 		return patch
 	}
 
@@ -8415,6 +8460,28 @@ func mergeSSEUsagePatch(usage *ClaudeUsage, patch *sseUsagePatch) {
 	if patch.hasCacheCreation1h {
 		usage.CacheCreation1hTokens = patch.cacheCreation1hTokens
 	}
+	if patch.hasKiroCredits {
+		usage.KiroCredits = patch.kiroCredits
+	}
+}
+
+// parseSSEUsageFloat 解析 SSE usage 字段中的浮点数（如 _sub2api_kiro_credits）。
+func parseSSEUsageFloat(value any) (float64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case json.Number:
+		if f, err := v.Float64(); err == nil {
+			return f, true
+		}
+	}
+	return 0, false
 }
 
 func parseSSEUsageInt(value any) (int, bool) {
@@ -9510,6 +9577,7 @@ func (s *GatewayService) buildRecordUsageLog(
 		CacheReadTokens:       result.Usage.CacheReadInputTokens,
 		CacheCreation5mTokens: result.Usage.CacheCreation5mTokens,
 		CacheCreation1hTokens: result.Usage.CacheCreation1hTokens,
+		KiroCredits:           kiroCreditsPtr(result.Usage.KiroCredits),
 		ImageOutputTokens:     result.Usage.ImageOutputTokens,
 		RateMultiplier:        multiplier,
 		AccountRateMultiplier: &accountRateMultiplier,

--- a/backend/internal/service/gateway_streaming_test.go
+++ b/backend/internal/service/gateway_streaming_test.go
@@ -393,3 +393,59 @@ func TestHandleStreamingResponse_FailoverBodyDoesNotLeakAddresses(t *testing.T) 
 	require.Contains(t, body, "connection reset by peer")
 	require.Contains(t, body, "upstream stream disconnected")
 }
+
+// --- Kiro 内部 usage 字段剥离 ---
+
+// TestHandleStreamingResponse_StripsKiroInternalCredits 验证 translator 经
+// _sub2api_kiro_credits 内部通道透传的真实 credits 被计费侧捕获，
+// 但不会出现在转发给客户端的 SSE 中。
+func TestHandleStreamingResponse_StripsKiroInternalCredits(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := newMinimalGatewayService()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	pr, pw := io.Pipe()
+	resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: pr}
+
+	go func() {
+		defer func() { _ = pw.Close() }()
+		_, _ = pw.Write([]byte("data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10}}}\n\n"))
+		_, _ = pw.Write([]byte("data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":15,\"_sub2api_kiro_credits\":1.25}}\n\n"))
+		_, _ = pw.Write([]byte("data: [DONE]\n\n"))
+	}()
+
+	result, err := svc.handleStreamingResponse(context.Background(), resp, c, &Account{ID: 1}, time.Now(), "model", "model", false)
+	_ = pr.Close()
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.usage)
+	require.InDelta(t, 1.25, result.usage.KiroCredits, 1e-9, "内部通道应捕获 credits")
+	require.Equal(t, 15, result.usage.OutputTokens)
+
+	body := rec.Body.String()
+	require.NotContains(t, body, "_sub2api_kiro_credits", "内部字段不得透传给客户端")
+	require.Contains(t, body, "\"output_tokens\":15", "其余 usage 字段应正常转发")
+}
+
+func TestStripSub2apiInternalUsageFields(t *testing.T) {
+	t.Run("removes field from data line", func(t *testing.T) {
+		line := `data: {"type":"message_delta","usage":{"output_tokens":15,"_sub2api_kiro_credits":1.25}}`
+		got := stripSub2apiInternalUsageFields(line)
+		require.NotContains(t, got, "_sub2api_kiro_credits")
+		require.Contains(t, got, `"output_tokens":15`)
+		require.True(t, len(got) > len("data: {}"))
+	})
+
+	t.Run("no-op without marker", func(t *testing.T) {
+		line := `data: {"type":"message_delta","usage":{"output_tokens":15}}`
+		require.Equal(t, line, stripSub2apiInternalUsageFields(line))
+	})
+
+	t.Run("no-op for non-data lines", func(t *testing.T) {
+		line := `event: message_delta`
+		require.Equal(t, line, stripSub2apiInternalUsageFields(line))
+	})
+}

--- a/backend/internal/service/group.go
+++ b/backend/internal/service/group.go
@@ -74,6 +74,10 @@ type Group struct {
 	KiroStickySessionTTLSeconds int
 	KiroCacheEmulationRatio     float64
 
+	// Kiro 反向 token 缩放锚定单价：每 credit 对应 USD 余额（仅 platform=kiro 生效）。
+	// 0 = 禁用反向缩放（保持原有按 token 计费行为）。
+	KiroCreditTargetUSD float64
+
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
@@ -165,6 +169,48 @@ func normalizeKiroCacheEmulationFields(g *Group) {
 
 func NormalizeGroupRuntimeFields(g *Group) {
 	normalizeKiroCacheEmulationFields(g)
+	normalizeKiroCreditTargetFields(g)
+}
+
+// kiroCreditTargetUSDMaxCap 是 KiroCreditTargetUSD 的安全上限。
+// 防止配置错误（如多写一位小数）导致计费暴涨；超出会被 cap。
+const kiroCreditTargetUSDMaxCap = 1.0
+
+// EffectiveKiroCreditTargetUSD 返回当前 group 用于反向缩放的锚定单价。
+// 仅当 Platform = kiro 且配置 > 0 时返回该值（含上限 cap），否则返回 0。
+func (g *Group) EffectiveKiroCreditTargetUSD() float64 {
+	if g == nil || g.Platform != PlatformKiro {
+		return 0
+	}
+	v := g.KiroCreditTargetUSD
+	if v <= 0 {
+		return 0
+	}
+	if v > kiroCreditTargetUSDMaxCap {
+		return kiroCreditTargetUSDMaxCap
+	}
+	return v
+}
+
+// KiroReverseScalingEnabled 报告该 group 是否启用 Kiro 反向 token 缩放。
+func (g *Group) KiroReverseScalingEnabled() bool {
+	return g.EffectiveKiroCreditTargetUSD() > 0
+}
+
+func normalizeKiroCreditTargetFields(g *Group) {
+	if g == nil {
+		return
+	}
+	if g.Platform != PlatformKiro {
+		g.KiroCreditTargetUSD = 0
+		return
+	}
+	if g.KiroCreditTargetUSD < 0 {
+		g.KiroCreditTargetUSD = 0
+	}
+	if g.KiroCreditTargetUSD > kiroCreditTargetUSDMaxCap {
+		g.KiroCreditTargetUSD = kiroCreditTargetUSDMaxCap
+	}
 }
 
 func (g *Group) IsActive() bool {

--- a/backend/internal/service/group.go
+++ b/backend/internal/service/group.go
@@ -78,6 +78,11 @@ type Group struct {
 	// 0 = 禁用反向缩放（保持原有按 token 计费行为）。
 	KiroCreditTargetUSD float64
 
+	// Kiro 缓存强制比例中位数（仅 platform=kiro 生效）。
+	// 0 = 禁用；> 0 时把模拟缓存分布重塑成 Anthropic-like 形态（input 极小、
+	// cache_read 占大头）。配合 credit 反向缩放计费时为纯展示口径，不改变最终扣费。
+	KiroCacheForceRatioCenter float64
+
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
@@ -167,9 +172,50 @@ func normalizeKiroCacheEmulationFields(g *Group) {
 	g.KiroCacheEmulationRatio = normalizeKiroCacheEmulationRatio(g.KiroCacheEmulationRatio)
 }
 
+// kiroCacheForceRatioCenterMaxCap 是 KiroCacheForceRatioCenter 的安全上限。
+const kiroCacheForceRatioCenterMaxCap = 0.99
+
+// EffectiveKiroCacheForceRatioCenter 返回当前 group 实际使用的缓存强制比例中位数。
+// 仅当 Platform = kiro 且配置 > 0 时返回该值（含上限 cap），否则返回 0。
+func (g *Group) EffectiveKiroCacheForceRatioCenter() float64 {
+	if g == nil || g.Platform != PlatformKiro {
+		return 0
+	}
+	v := g.KiroCacheForceRatioCenter
+	if v <= 0 {
+		return 0
+	}
+	if v > kiroCacheForceRatioCenterMaxCap {
+		return kiroCacheForceRatioCenterMaxCap
+	}
+	return v
+}
+
+// KiroCacheForceEnabled 报告该 group 是否启用了缓存分布强制重塑。
+func (g *Group) KiroCacheForceEnabled() bool {
+	return g.EffectiveKiroCacheForceRatioCenter() > 0
+}
+
+func normalizeKiroCacheForceFields(g *Group) {
+	if g == nil {
+		return
+	}
+	if g.Platform != PlatformKiro {
+		g.KiroCacheForceRatioCenter = 0
+		return
+	}
+	if g.KiroCacheForceRatioCenter < 0 {
+		g.KiroCacheForceRatioCenter = 0
+	}
+	if g.KiroCacheForceRatioCenter > kiroCacheForceRatioCenterMaxCap {
+		g.KiroCacheForceRatioCenter = kiroCacheForceRatioCenterMaxCap
+	}
+}
+
 func NormalizeGroupRuntimeFields(g *Group) {
 	normalizeKiroCacheEmulationFields(g)
 	normalizeKiroCreditTargetFields(g)
+	normalizeKiroCacheForceFields(g)
 }
 
 // kiroCreditTargetUSDMaxCap 是 KiroCreditTargetUSD 的安全上限。

--- a/backend/internal/service/kiro_cache_emulation.go
+++ b/backend/internal/service/kiro_cache_emulation.go
@@ -77,7 +77,98 @@ func (s *GatewayService) buildKiroCacheEmulationUsage(account *Account, group *G
 	if result.CacheReadInputTokens == 0 && result.CacheCreationInputTokens == 0 {
 		return nil
 	}
+	// 缓存分布强制重塑：把模拟出的 input/cache_read/cache_creation 拆分重塑成
+	// Anthropic-like 形态（input 极小、cache_read 占大头），仅展示口径，不改总额。
+	if group.KiroCacheForceEnabled() {
+		applyKiroCacheForceRatio(result)
+	}
 	return result
+}
+
+// kiroCacheForceBreakpoint 是 Anthropic-like 缓存分布拟合段端点。
+type kiroCacheForceBreakpoint struct {
+	threshold float64
+	readRatio float64
+	inputCap  int
+}
+
+// kiroCacheForceFit 基于真实 Anthropic Claude Code 直连流量反推的分段拟合表：
+// 实测（按 total_input 分桶）input 不随 total 增长（≥20k 恒 p50≈2，故 inputCap=1，
+// 配合下游可能的缩放落到 ~2），cache_read 占比在 0.82~0.93 之间。
+var kiroCacheForceFit = []kiroCacheForceBreakpoint{
+	{0, 0.600, 1},
+	{5000, 0.800, 1},
+	{20000, 0.830, 1},
+	{100000, 0.900, 1},
+	{500000, 0.930, 1},
+	{2000000, 0.915, 1},
+}
+
+// computeKiroCacheForceRatio 给定 total_input_tokens，返回 (cache_read_ratio, input_cap)。
+func computeKiroCacheForceRatio(total int) (float64, int) {
+	t := float64(total)
+	bp := kiroCacheForceFit
+	if t <= bp[0].threshold {
+		return bp[0].readRatio, bp[0].inputCap
+	}
+	if t >= bp[len(bp)-1].threshold {
+		return bp[len(bp)-1].readRatio, bp[len(bp)-1].inputCap
+	}
+	for i := 0; i < len(bp)-1; i++ {
+		if t >= bp[i].threshold && t < bp[i+1].threshold {
+			seg := bp[i+1].threshold - bp[i].threshold
+			if seg <= 0 {
+				return bp[i].readRatio, bp[i].inputCap
+			}
+			p := (t - bp[i].threshold) / seg
+			ratio := bp[i].readRatio + p*(bp[i+1].readRatio-bp[i].readRatio)
+			cap := bp[i].inputCap
+			if bp[i+1].inputCap > cap {
+				cap = bp[i+1].inputCap
+			}
+			return ratio, cap
+		}
+	}
+	return bp[len(bp)-1].readRatio, bp[len(bp)-1].inputCap
+}
+
+// applyKiroCacheForceRatio 把模拟缓存分布重塑成 Anthropic-like：input 钳到极小，
+// 剩余按 readRatio 切给 cache_read / cache_creation；总量守恒。
+func applyKiroCacheForceRatio(u *kiroCacheEmulationUsage) {
+	if u == nil {
+		return
+	}
+	total := u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
+	// 极短请求：只兜底 input=0 → 1。
+	if total <= 100 {
+		if u.InputTokens == 0 && (u.CacheReadInputTokens > 0 || u.CacheCreationInputTokens > 0) {
+			u.InputTokens = 1
+		}
+		return
+	}
+	readRatio, inputCap := computeKiroCacheForceRatio(total)
+	newInput := inputCap
+	if newInput >= total-2 {
+		newInput = total - 2
+	}
+	if newInput < 1 {
+		newInput = 1
+	}
+	remaining := total - newInput
+	newCacheRead := int(math.Round(float64(remaining) * readRatio))
+	if newCacheRead >= remaining {
+		newCacheRead = remaining - 1
+	}
+	if newCacheRead < 0 {
+		newCacheRead = 0
+	}
+	newCacheCreation := remaining - newCacheRead
+	u.InputTokens = newInput
+	u.CacheReadInputTokens = newCacheRead
+	// 真实数据显示 cache_creation 几乎全在 5m TTL。
+	u.CacheCreation5mInputTokens = newCacheCreation
+	u.CacheCreation1hInputTokens = 0
+	u.CacheCreationInputTokens = newCacheCreation
 }
 
 func scaleKiroCacheTokens(tokens int, ratio float64) int {

--- a/backend/internal/service/kiro_cache_force_test.go
+++ b/backend/internal/service/kiro_cache_force_test.go
@@ -1,0 +1,48 @@
+//go:build unit
+
+package service
+
+import "testing"
+
+// TestApplyKiroCacheForceRatio_ReshapesDistribution 验证强制重塑把分布变成
+// Anthropic-like：input 极小、cache_read 占大头，且总量守恒。
+func TestApplyKiroCacheForceRatio_ReshapesDistribution(t *testing.T) {
+	u := &kiroCacheEmulationUsage{InputTokens: 50000, CacheReadInputTokens: 0, CacheCreationInputTokens: 0}
+	applyKiroCacheForceRatio(u)
+
+	total := u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
+	if total != 50000 {
+		t.Fatalf("总量必须守恒，got %d", total)
+	}
+	if u.InputTokens >= 100 {
+		t.Fatalf("input 应被压到极小，got %d", u.InputTokens)
+	}
+	if u.CacheReadInputTokens <= u.CacheCreationInputTokens {
+		t.Fatalf("cache_read 应占大头：cr=%d cc=%d", u.CacheReadInputTokens, u.CacheCreationInputTokens)
+	}
+	if u.CacheCreation5mInputTokens != u.CacheCreationInputTokens {
+		t.Fatalf("cache_creation 应归到 5m TTL")
+	}
+}
+
+// TestApplyKiroCacheForceRatio_ShortRequest 验证极短请求只兜底 input=0->1。
+func TestApplyKiroCacheForceRatio_ShortRequest(t *testing.T) {
+	u := &kiroCacheEmulationUsage{InputTokens: 0, CacheReadInputTokens: 30}
+	applyKiroCacheForceRatio(u)
+	if u.InputTokens != 1 || u.CacheReadInputTokens != 30 {
+		t.Fatalf("极短请求应只兜底 input=1，got input=%d cr=%d", u.InputTokens, u.CacheReadInputTokens)
+	}
+}
+
+// TestEffectiveKiroCacheForceRatioCenter 验证取值/兜底/cap。
+func TestEffectiveKiroCacheForceRatioCenter(t *testing.T) {
+	if v := (&Group{Platform: PlatformKiro, KiroCacheForceRatioCenter: 0.925}).EffectiveKiroCacheForceRatioCenter(); v != 0.925 {
+		t.Fatalf("want 0.925, got %v", v)
+	}
+	if v := (&Group{Platform: PlatformAnthropic, KiroCacheForceRatioCenter: 0.925}).EffectiveKiroCacheForceRatioCenter(); v != 0 {
+		t.Fatalf("非 kiro 平台应返回 0, got %v", v)
+	}
+	if v := (&Group{Platform: PlatformKiro, KiroCacheForceRatioCenter: 2}).EffectiveKiroCacheForceRatioCenter(); v != kiroCacheForceRatioCenterMaxCap {
+		t.Fatalf("超 cap 应被钳到 %v, got %v", kiroCacheForceRatioCenterMaxCap, v)
+	}
+}

--- a/backend/internal/service/kiro_credit_direct_cost_test.go
+++ b/backend/internal/service/kiro_credit_direct_cost_test.go
@@ -1,0 +1,65 @@
+//go:build unit
+
+package service
+
+import (
+	"math"
+	"testing"
+)
+
+func approxEqual(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+// TestApplyKiroCreditDirectCost_FinalPriceIgnoresMultiplier 验证 Kiro credit 直接计费：
+// 无论 token 成本经过多少倍率，最终 ActualCost == credits × target_usd。
+func TestApplyKiroCreditDirectCost_FinalPriceIgnoresMultiplier(t *testing.T) {
+	// 模拟一个已被 rate multiplier(1.5) 改写过的 cost：token 成本本来 0.10，×1.5 = 0.15。
+	cost := &CostBreakdown{
+		InputCost:     0.02,
+		OutputCost:    0.05,
+		CacheReadCost: 0.03,
+		TotalCost:     0.10,
+		ActualCost:    0.15, // 已叠加 1.5 倍率
+	}
+	credits := 1.25
+	target := 0.04 // USD/credit
+
+	applyKiroCreditDirectCost(cost, credits, target)
+
+	want := credits * target // 0.05
+	if !approxEqual(cost.ActualCost, want) {
+		t.Fatalf("ActualCost 应严格等于 credits×target=%.4f（不叠加倍率），实际 %.4f", want, cost.ActualCost)
+	}
+	if !approxEqual(cost.TotalCost, want) {
+		t.Fatalf("TotalCost 应等于 %.4f，实际 %.4f", want, cost.TotalCost)
+	}
+	// 子项之和应保持等于 TotalCost 的不变式。
+	sum := cost.InputCost + cost.OutputCost + cost.ImageOutputCost + cost.CacheCreationCost + cost.CacheReadCost
+	if !approxEqual(sum, cost.TotalCost) {
+		t.Fatalf("子项之和(%.6f)应等于 TotalCost(%.6f)", sum, cost.TotalCost)
+	}
+}
+
+// TestApplyKiroCreditDirectCost_ZeroTotalFallback 验证 token 成本为 0 时兜底：
+// 全部归到 input 子项，ActualCost 仍 == credits×target。
+func TestApplyKiroCreditDirectCost_ZeroTotalFallback(t *testing.T) {
+	cost := &CostBreakdown{TotalCost: 0, ActualCost: 0}
+	applyKiroCreditDirectCost(cost, 2.0, 0.04)
+	want := 2.0 * 0.04
+	if !approxEqual(cost.ActualCost, want) || !approxEqual(cost.InputCost, want) {
+		t.Fatalf("TotalCost=0 兜底失败：ActualCost=%.4f InputCost=%.4f want=%.4f", cost.ActualCost, cost.InputCost, want)
+	}
+}
+
+// TestApplyKiroCreditDirectCost_NoopOnZeroInputs 验证 credits/target<=0 或 nil 时不改动。
+func TestApplyKiroCreditDirectCost_NoopOnZeroInputs(t *testing.T) {
+	cost := &CostBreakdown{TotalCost: 0.10, ActualCost: 0.15}
+	applyKiroCreditDirectCost(cost, 0, 0.04)
+	if !approxEqual(cost.ActualCost, 0.15) {
+		t.Fatalf("credits=0 时不应改动 ActualCost，实际 %.4f", cost.ActualCost)
+	}
+	applyKiroCreditDirectCost(cost, 1.0, 0)
+	if !approxEqual(cost.ActualCost, 0.15) {
+		t.Fatalf("target=0 时不应改动 ActualCost，实际 %.4f", cost.ActualCost)
+	}
+	applyKiroCreditDirectCost(nil, 1.0, 0.04) // 不应 panic
+}

--- a/backend/internal/service/kiro_credit_direct_cost_test.go
+++ b/backend/internal/service/kiro_credit_direct_cost_test.go
@@ -63,3 +63,14 @@ func TestApplyKiroCreditDirectCost_NoopOnZeroInputs(t *testing.T) {
 	}
 	applyKiroCreditDirectCost(nil, 1.0, 0.04) // 不应 panic
 }
+
+// TestApplyKiroCreditDirectCost_SanityCapClamps 验证畸高 credits 被 clamp 到上限，
+// 防止上游异常一次扣巨额。
+func TestApplyKiroCreditDirectCost_SanityCapClamps(t *testing.T) {
+	cost := &CostBreakdown{TotalCost: 0.10, ActualCost: 0.10}
+	applyKiroCreditDirectCost(cost, 100000, 1.0) // 畸高 credits
+	want := kiroCreditsPerRequestSanityCap * 1.0
+	if !approxEqual(cost.ActualCost, want) {
+		t.Fatalf("credits 应被 clamp 到 cap，ActualCost want=%.2f got=%.2f", want, cost.ActualCost)
+	}
+}

--- a/backend/internal/service/kiro_runtime.go
+++ b/backend/internal/service/kiro_runtime.go
@@ -242,6 +242,7 @@ func (s *GatewayService) forwardKiroMessages(ctx context.Context, c *gin.Context
 
 	cacheUsage := s.buildKiroCacheEmulationUsage(account, parsed.Group, body, mappedModel, inputTokens)
 	requestCtx.CacheEmulationUsage = cacheUsage.toKiroUsage()
+	applyKiroReverseScalingContext(&requestCtx, parsed.Group, originalModel)
 	parseResult, err := kiropkg.ParseNonStreamingEventStreamWithContext(resp.Body, originalModel, requestCtx)
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{
@@ -289,7 +290,7 @@ func (s *GatewayService) openKiroAnthropicStreamResponse(ctx context.Context, ac
 		headers := make(http.Header)
 		headers.Set("Content-Type", "text/event-stream")
 		go func() {
-			streamErr := s.streamKiroWebSearchAsAnthropic(ctx, account, anthropicBody, mappedModel, requestModel, token, inputTokens, headers, pw, cacheUsage)
+			streamErr := s.streamKiroWebSearchAsAnthropic(ctx, account, group, anthropicBody, mappedModel, requestModel, token, inputTokens, headers, pw, cacheUsage)
 			if streamErr != nil {
 				_ = pw.CloseWithError(streamErr)
 				return
@@ -316,6 +317,7 @@ func (s *GatewayService) openKiroAnthropicStreamResponse(ctx context.Context, ac
 	}
 	cacheUsage := s.buildKiroCacheEmulationUsage(account, group, anthropicBody, mappedModel, inputTokens)
 	requestCtx.CacheEmulationUsage = cacheUsage.toKiroUsage()
+	applyKiroReverseScalingContext(&requestCtx, group, requestModel)
 
 	pr, pw := io.Pipe()
 	wrappedHeaders := resp.Header.Clone()
@@ -716,11 +718,24 @@ func estimateKiroInputTokens(body []byte) int {
 	return tokens
 }
 
+// kiroCreditsPtr 把 KiroCredits float64 转为可空指针：
+// 仅 Kiro 平台请求会有 credits > 0 才写入 db.kiro_credits 列；
+// 其他平台或 credits=0 写 NULL 表示"无可信 credit 数据"。
+func kiroCreditsPtr(credits float64) *float64 {
+	if credits <= 0 {
+		return nil
+	}
+	v := credits
+	return &v
+}
+
 func kiroUsageToClaude(usage kiropkg.Usage, fallbackInput int) ClaudeUsage {
 	inputTokens := usage.InputTokens
 	if inputTokens == 0 {
 		inputTokens = fallbackInput
 	}
+	// 反向缩放已在 translator.go 流结束时应用（通过 KiroRequestContext 注入），
+	// 此处 usage 已是缩放后的值。KiroCredits 字段透传，给 usage_logs.kiro_credits 做对账。
 	return ClaudeUsage{
 		InputTokens:              inputTokens,
 		OutputTokens:             usage.OutputTokens,
@@ -728,6 +743,40 @@ func kiroUsageToClaude(usage kiropkg.Usage, fallbackInput int) ClaudeUsage {
 		CacheCreationInputTokens: usage.CacheCreationInputTokens,
 		CacheCreation5mTokens:    usage.CacheCreation5mInputTokens,
 		CacheCreation1hTokens:    usage.CacheCreation1hInputTokens,
+		KiroCredits:              usage.KiroCredits,
+	}
+}
+
+// applyKiroReverseScalingContext 把 group 配置注入到 KiroRequestContext，
+// 让 translator 在流结束时执行反向 token 缩放。
+//
+// 必须在所有调用 ParseNonStreamingEventStreamWithContext / StreamEventStreamAsAnthropicWithContext
+// 之前调用，确保流式和非流式路径都覆盖。
+func applyKiroReverseScalingContext(ctx *kiropkg.KiroRequestContext, group *Group, model string) {
+	if ctx == nil || group == nil {
+		return
+	}
+	target := group.EffectiveKiroCreditTargetUSD()
+	if target <= 0 {
+		return
+	}
+	pIn, pOut, pCC, pCR := kiroReverseScalingPrices(model)
+	ctx.ReverseScalingTargetUSD = target
+	ctx.ReverseScalingPrices = [4]float64{pIn, pOut, pCC, pCR}
+}
+
+// kiroReverseScalingPrices 返回反向缩放算法用的 Anthropic 标准价（USD per 1M tokens）。
+// 注意：这是仅用于"反算 K"的参考价，不影响 sub2api 真实计费表。
+func kiroReverseScalingPrices(model string) (pIn, pOut, pCC, pCR float64) {
+	m := strings.ToLower(model)
+	switch {
+	case strings.Contains(m, "haiku"):
+		return 1.0, 5.0, 1.25, 0.10
+	case strings.Contains(m, "sonnet"):
+		return 3.0, 15.0, 3.75, 0.30
+	default:
+		// Opus 4.x（默认，含 thinking 变体）
+		return 5.0, 25.0, 6.25, 0.50
 	}
 }
 

--- a/backend/internal/service/kiro_websearch.go
+++ b/backend/internal/service/kiro_websearch.go
@@ -48,9 +48,9 @@ func (w *kiroStreamChunkCollector) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func bufferKiroAnthropicStream(ctx context.Context, body io.Reader, responseModel string, inputTokens int) ([][]byte, *kiropkg.StreamResult, error) {
+func bufferKiroAnthropicStream(ctx context.Context, body io.Reader, responseModel string, inputTokens int, requestCtx kiropkg.KiroRequestContext) ([][]byte, *kiropkg.StreamResult, error) {
 	collector := &kiroStreamChunkCollector{}
-	result, err := kiropkg.StreamEventStreamAsAnthropicWithContext(ctx, body, collector, responseModel, inputTokens, kiropkg.KiroRequestContext{})
+	result, err := kiropkg.StreamEventStreamAsAnthropicWithContext(ctx, body, collector, responseModel, inputTokens, requestCtx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -106,7 +106,7 @@ func writeAnthropicMessageStart(w io.Writer, msgID, model string, inputTokens in
 }
 
 func (s *GatewayService) streamKiroWebSearchAsAnthropic(
-	ctx context.Context, account *Account, anthropicBody []byte, mappedModel, requestModel, token string, inputTokens int, headers http.Header, w io.Writer, cacheUsage *kiroCacheEmulationUsage,
+	ctx context.Context, account *Account, group *Group, anthropicBody []byte, mappedModel, requestModel, token string, inputTokens int, headers http.Header, w io.Writer, cacheUsage *kiroCacheEmulationUsage,
 ) error {
 	query := kiropkg.ExtractSearchQuery(anthropicBody)
 	if strings.TrimSpace(query) == "" {
@@ -123,6 +123,10 @@ func (s *GatewayService) streamKiroWebSearchAsAnthropic(
 	if err := writeAnthropicMessageStart(w, "", requestModel, inputTokens, cacheUsage); err != nil {
 		return err
 	}
+
+	// 反向缩放上下文：每次迭代都用同一个 wsCtx（cacheUsage + reverse-scaling 配置）。
+	wsCtx := kiropkg.KiroRequestContext{CacheEmulationUsage: cacheUsage.toKiroUsage()}
+	applyKiroReverseScalingContext(&wsCtx, group, requestModel)
 
 	for iteration := 0; iteration < kiroMaxWebSearchIterations; iteration++ {
 		s.prefetchKiroWebSearchDescription(ctx, account, token)
@@ -155,7 +159,7 @@ func (s *GatewayService) streamKiroWebSearchAsAnthropic(
 
 		chunks, _, streamErr := func() ([][]byte, *kiropkg.StreamResult, error) {
 			defer func() { _ = resp.Body.Close() }()
-			return bufferKiroAnthropicStream(ctx, resp.Body, requestModel, inputTokens)
+			return bufferKiroAnthropicStream(ctx, resp.Body, requestModel, inputTokens, wsCtx)
 		}()
 		if streamErr != nil {
 			return streamErr
@@ -247,7 +251,9 @@ func (s *GatewayService) executeKiroWebSearch(ctx context.Context, account *Acco
 				cacheUsage = s.buildKiroCacheEmulationUsage(account, group, anthropicBody, mappedModel, inputTokens)
 				cacheUsageResolved = true
 			}
-			return kiropkg.ParseNonStreamingEventStreamWithContext(resp.Body, requestModel, kiropkg.KiroRequestContext{CacheEmulationUsage: cacheUsage.toKiroUsage()})
+			wsCtx := kiropkg.KiroRequestContext{CacheEmulationUsage: cacheUsage.toKiroUsage()}
+			applyKiroReverseScalingContext(&wsCtx, group, requestModel)
+			return kiropkg.ParseNonStreamingEventStreamWithContext(resp.Body, requestModel, wsCtx)
 		}()
 		if parseErr != nil {
 			return nil, parseErr

--- a/backend/internal/service/kiro_websearch.go
+++ b/backend/internal/service/kiro_websearch.go
@@ -128,6 +128,10 @@ func (s *GatewayService) streamKiroWebSearchAsAnthropic(
 	wsCtx := kiropkg.KiroRequestContext{CacheEmulationUsage: cacheUsage.toKiroUsage()}
 	applyKiroReverseScalingContext(&wsCtx, group, requestModel)
 
+	// 多轮 web search 每轮都消耗 Kiro credits，累计所有轮次，最后一轮转发前把累计
+	// 总额写回最终 message_delta，避免计费/对账只记最后一轮（中间轮 message_delta 被过滤）。
+	var totalKiroCredits float64
+
 	for iteration := 0; iteration < kiroMaxWebSearchIterations; iteration++ {
 		s.prefetchKiroWebSearchDescription(ctx, account, token)
 
@@ -157,12 +161,15 @@ func (s *GatewayService) streamKiroWebSearchAsAnthropic(
 			return &kiroWebSearchHTTPError{Response: resp}
 		}
 
-		chunks, _, streamErr := func() ([][]byte, *kiropkg.StreamResult, error) {
+		chunks, streamResult, streamErr := func() ([][]byte, *kiropkg.StreamResult, error) {
 			defer func() { _ = resp.Body.Close() }()
 			return bufferKiroAnthropicStream(ctx, resp.Body, requestModel, inputTokens, wsCtx)
 		}()
 		if streamErr != nil {
 			return streamErr
+		}
+		if streamResult != nil {
+			totalKiroCredits += streamResult.Usage.KiroCredits
 		}
 
 		analysis := kiropkg.AnalyzeBufferedStream(chunks)
@@ -183,6 +190,8 @@ func (s *GatewayService) streamKiroWebSearchAsAnthropic(
 			continue
 		}
 
+		// 最后一轮：把累计 credits 写回最终 message_delta，再转发给客户端/计费层。
+		chunks = kiropkg.RewriteFinalKiroCredits(chunks, totalKiroCredits)
 		for _, chunk := range chunks {
 			adjusted, shouldForward := kiropkg.AdjustSSEChunk(chunk, nextContentBlockIndex)
 			if !shouldForward {
@@ -215,6 +224,9 @@ func (s *GatewayService) executeKiroWebSearch(ctx context.Context, account *Acco
 	requestID := ""
 	var cacheUsage *kiroCacheEmulationUsage
 	cacheUsageResolved := false
+	// 多轮 web search 每轮各自累计 credits；只返回最后一轮 parseResult，故需在循环外汇总，
+	// 最终把累计总额写回 parseResult.Usage，确保计费/对账记的是所有轮次之和。
+	var totalKiroCredits float64
 
 	for iteration := 0; iteration < kiroMaxWebSearchIterations; iteration++ {
 		s.prefetchKiroWebSearchDescription(ctx, account, token)
@@ -258,6 +270,7 @@ func (s *GatewayService) executeKiroWebSearch(ctx context.Context, account *Acco
 		if parseErr != nil {
 			return nil, parseErr
 		}
+		totalKiroCredits += parseResult.Usage.KiroCredits
 		if requestID == "" {
 			requestID = buildKiroRequestID(resp)
 		}
@@ -268,6 +281,8 @@ func (s *GatewayService) executeKiroWebSearch(ctx context.Context, account *Acco
 			if injectErr == nil {
 				parseResult.ResponseBody = finalBody
 			}
+			// 用累计总额覆写最后一轮的 credits，再交给计费层。
+			parseResult.Usage.KiroCredits = totalKiroCredits
 			return &kiroWebSearchExecution{
 				ResponseBody: parseResult.ResponseBody,
 				Usage:        kiroUsageToClaude(parseResult.Usage, inputTokens),

--- a/backend/internal/service/usage_log.go
+++ b/backend/internal/service/usage_log.go
@@ -134,6 +134,10 @@ type UsageLog struct {
 	CacheCreation5mTokens int `gorm:"column:cache_creation_5m_tokens"`
 	CacheCreation1hTokens int `gorm:"column:cache_creation_1h_tokens"`
 
+	// KiroCredits 来自上游 meteringEvent.usage 累加（仅 Kiro 平台有值）。
+	// 写到 usage_logs.kiro_credits 用于事后对账：cost ≡ KiroCredits × group.kiro_credit_target_usd。
+	KiroCredits *float64 `gorm:"column:kiro_credits"`
+
 	ImageOutputTokens int
 	ImageOutputCost   float64
 

--- a/backend/migrations/153_add_group_kiro_credit_target_usd.sql
+++ b/backend/migrations/153_add_group_kiro_credit_target_usd.sql
@@ -1,0 +1,18 @@
+-- Add Kiro reverse-token-scaling anchor price to groups.
+-- USD value billed per Kiro credit. 0 = disabled (default).
+ALTER TABLE groups
+  ADD COLUMN IF NOT EXISTS kiro_credit_target_usd DECIMAL(8,4) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN groups.kiro_credit_target_usd IS
+  'Kiro 反向 token 缩放锚定单价：每个 credit 对应的 sub2api USD 余额。0=禁用，仅 platform=kiro 生效。';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'groups_kiro_credit_target_usd_range'
+  ) THEN
+    ALTER TABLE groups
+      ADD CONSTRAINT groups_kiro_credit_target_usd_range
+      CHECK (kiro_credit_target_usd >= 0 AND kiro_credit_target_usd <= 10);
+  END IF;
+END $$;

--- a/backend/migrations/153_add_group_kiro_credit_target_usd.sql
+++ b/backend/migrations/153_add_group_kiro_credit_target_usd.sql
@@ -13,6 +13,6 @@ BEGIN
   ) THEN
     ALTER TABLE groups
       ADD CONSTRAINT groups_kiro_credit_target_usd_range
-      CHECK (kiro_credit_target_usd >= 0 AND kiro_credit_target_usd <= 10);
+      CHECK (kiro_credit_target_usd >= 0 AND kiro_credit_target_usd <= 1);
   END IF;
 END $$;

--- a/backend/migrations/154_add_usage_log_kiro_credits.sql
+++ b/backend/migrations/154_add_usage_log_kiro_credits.sql
@@ -1,0 +1,11 @@
+-- Add Kiro real credits column to usage_logs.
+-- 来源：上游 meteringEvent.usage 字段（浮点 credit 数）累加。
+-- 仅 Kiro 平台请求会写入，其他平台保持 NULL。
+-- 用于事后对账（sub2api total_cost ≡ kiro_credits × group.kiro_credit_target_usd）。
+ALTER TABLE usage_logs
+  ADD COLUMN IF NOT EXISTS kiro_credits NUMERIC(10,4);
+
+COMMENT ON COLUMN usage_logs.kiro_credits IS
+  'Kiro 上游 meteringEvent.usage 累加值（真实 credits 消耗，浮点）。仅 platform=kiro 写入，其他 NULL。';
+
+-- 配套索引见 155_add_usage_log_kiro_credits_index_notx.sql（非事务建索引，避免锁大表）。

--- a/backend/migrations/155_add_usage_log_kiro_credits_index_notx.sql
+++ b/backend/migrations/155_add_usage_log_kiro_credits_index_notx.sql
@@ -1,0 +1,6 @@
+-- 155_add_usage_log_kiro_credits_index_notx.sql
+-- kiro_credits 对账聚合用的部分索引（按时间范围筛 platform=kiro 的记录）。
+-- 非事务迁移（_notx）：CREATE INDEX CONCURRENTLY 不可在事务内执行，
+-- 用 CONCURRENTLY 避免在大体量 usage_logs 表上建索引时阻塞写入。
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_usage_logs_kiro_credits_at
+  ON usage_logs (created_at) WHERE kiro_credits IS NOT NULL;

--- a/backend/migrations/156_add_group_kiro_cache_force_ratio_center.sql
+++ b/backend/migrations/156_add_group_kiro_cache_force_ratio_center.sql
@@ -1,0 +1,6 @@
+-- Kiro group-level cache-distribution reshaping center.
+-- 0 = disabled (default, backfills existing rows). > 0 reshapes the emulated
+-- cache split into an Anthropic-like distribution (tiny input, cache_read
+-- dominant) for display realism only; it does not change billed totals.
+ALTER TABLE groups
+    ADD COLUMN IF NOT EXISTS kiro_cache_force_ratio_center DECIMAL(5,4) NOT NULL DEFAULT 0;

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2241,6 +2241,8 @@ export default {
         enabled: 'Enable cache emulation',
         ratio: 'Cache ratio',
         ratioHint: '0 to 1. For example, 0.5 applies half of the simulated cache tokens.',
+        forceRatio: 'Enable Anthropic-like cache distribution',
+        forceRatioHint: 'Reshapes the displayed token distribution to match real Anthropic direct usage (tiny input, cache_read dominant). Display only; does not change the real billed total.',
         stickyRouting: 'Enable Kiro account sticky routing',
         stickyRoutingHint: 'When enabled, multi-turn conversations are pinned to the same account when possible. X-Session-ID still takes precedence for explicit session binding.',
         stickyTTL: 'Sticky binding TTL (seconds)',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2324,6 +2324,8 @@ export default {
         enabled: '启用模拟缓存',
         ratio: '缓存比例',
         ratioHint: '范围 0 到 1，例如 0.5 表示只生效一半模拟缓存 token。',
+        forceRatio: '启用 Anthropic-like 缓存分布模拟',
+        forceRatioHint: '把 token 按真实 Anthropic 直连分布重写显示口径（input 极小、cache_read 占大头）；仅展示美化，不改变真实计费总额。',
         stickyRouting: '启用 Kiro 账号粘性路由',
         stickyRoutingHint: '开启后，同一会话的多轮对话会尽量固定到同一账号；请求头传 X-Session-ID 时仍优先使用显式会话绑定。',
         stickyTTL: '粘性绑定时长（秒）',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -533,6 +533,7 @@ export interface Group {
   kiro_cache_emulation_enabled: boolean
   kiro_cache_emulation_ratio: number
   kiro_credit_target_usd?: number
+  kiro_cache_force_ratio_center?: number
   created_at: string
   updated_at: string
 }
@@ -660,6 +661,7 @@ export interface CreateGroupRequest {
   kiro_cache_emulation_enabled?: boolean
   kiro_cache_emulation_ratio?: number
   kiro_credit_target_usd?: number
+  kiro_cache_force_ratio_center?: number
   // 从指定分组复制账号
   copy_accounts_from_group_ids?: number[]
 }
@@ -700,6 +702,7 @@ export interface UpdateGroupRequest {
   kiro_cache_emulation_enabled?: boolean
   kiro_cache_emulation_ratio?: number
   kiro_credit_target_usd?: number
+  kiro_cache_force_ratio_center?: number
   copy_accounts_from_group_ids?: number[]
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -532,6 +532,7 @@ export interface Group {
   kiro_sticky_session_ttl_seconds: number
   kiro_cache_emulation_enabled: boolean
   kiro_cache_emulation_ratio: number
+  kiro_credit_target_usd?: number
   created_at: string
   updated_at: string
 }
@@ -658,6 +659,7 @@ export interface CreateGroupRequest {
   kiro_sticky_session_ttl_seconds?: number
   kiro_cache_emulation_enabled?: boolean
   kiro_cache_emulation_ratio?: number
+  kiro_credit_target_usd?: number
   // 从指定分组复制账号
   copy_accounts_from_group_ids?: number[]
 }
@@ -697,6 +699,7 @@ export interface UpdateGroupRequest {
   kiro_sticky_session_ttl_seconds?: number
   kiro_cache_emulation_enabled?: boolean
   kiro_cache_emulation_ratio?: number
+  kiro_credit_target_usd?: number
   copy_accounts_from_group_ids?: number[]
 }
 

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -692,6 +692,19 @@
             />
             <p class="input-hint">{{ t("admin.groups.kiroCache.ratioHint") }}</p>
           </div>
+          <div class="mt-4">
+            <label class="input-label">Kiro 反向缩放锚定单价（USD/credit）</label>
+            <input
+              v-model.number="createForm.kiro_credit_target_usd"
+              type="number"
+              step="0.0001"
+              min="0"
+              max="1"
+              class="input"
+              placeholder="0.0000"
+            />
+            <p class="input-hint">每 credit 对应的 sub2api USD 余额。0 = 禁用反向缩放（按 token × Anthropic 标准价计费）。</p>
+          </div>
         </div>
 
         <div class="border-t pt-4">
@@ -2026,6 +2039,19 @@
               placeholder="1"
             />
             <p class="input-hint">{{ t("admin.groups.kiroCache.ratioHint") }}</p>
+          </div>
+          <div class="mt-4">
+            <label class="input-label">Kiro 反向缩放锚定单价（USD/credit）</label>
+            <input
+              v-model.number="editForm.kiro_credit_target_usd"
+              type="number"
+              step="0.0001"
+              min="0"
+              max="1"
+              class="input"
+              placeholder="0.0000"
+            />
+            <p class="input-hint">每 credit 对应的 sub2api USD 余额。0 = 禁用反向缩放（按 token × Anthropic 标准价计费）。</p>
           </div>
         </div>
 
@@ -3481,6 +3507,8 @@ const createForm = reactive({
   kiro_auto_sticky_enabled: true,
   kiro_sticky_session_ttl_seconds: 3600,
   kiro_cache_emulation_ratio: 1,
+  // Kiro 反向 token 缩放锚定单价（仅 Kiro 平台；0=禁用）
+  kiro_credit_target_usd: 0 as number,
 });
 
 // 简单账号类型（用于模型路由选择）
@@ -3818,6 +3846,8 @@ const editForm = reactive({
   kiro_auto_sticky_enabled: true,
   kiro_sticky_session_ttl_seconds: 3600,
   kiro_cache_emulation_ratio: 1,
+  // Kiro 反向 token 缩放锚定单价（仅 Kiro 平台；0=禁用）
+  kiro_credit_target_usd: 0 as number,
 });
 
 type ImagePricingFormState = {
@@ -4059,6 +4089,7 @@ const closeCreateModal = () => {
   createForm.kiro_auto_sticky_enabled = true;
   createForm.kiro_sticky_session_ttl_seconds = 3600;
   createForm.kiro_cache_emulation_ratio = 1;
+  createForm.kiro_credit_target_usd = 0;
   resetModelsListState(createModelsListState);
   createModelRoutingRules.value = [];
 };
@@ -4153,6 +4184,7 @@ const handleCreateGroup = async () => {
       requestData.kiro_sticky_session_ttl_seconds = 0;
       requestData.kiro_cache_emulation_enabled = false;
       requestData.kiro_cache_emulation_ratio = 0;
+      requestData.kiro_credit_target_usd = 0;
     } else {
       requestData.kiro_sticky_session_ttl_seconds = normalizeKiroStickySessionTTL(
         requestData.kiro_sticky_session_ttl_seconds,
@@ -4227,6 +4259,7 @@ const handleEdit = async (group: AdminGroup) => {
     group.kiro_sticky_session_ttl_seconds ?? 3600;
   editForm.kiro_cache_emulation_enabled = group.kiro_cache_emulation_enabled ?? false;
   editForm.kiro_cache_emulation_ratio = group.kiro_cache_emulation_ratio ?? 1;
+  editForm.kiro_credit_target_usd = group.kiro_credit_target_usd ?? 0;
   resetModelsListState(editModelsListState, group.models_list_config);
   // 加载模型路由规则（异步加载账号名称）
   editModelRoutingRules.value = await convertApiFormatToRoutingRules(
@@ -4308,6 +4341,7 @@ const handleUpdateGroup = async () => {
       payload.kiro_sticky_session_ttl_seconds = 0;
       payload.kiro_cache_emulation_enabled = false;
       payload.kiro_cache_emulation_ratio = 0;
+      payload.kiro_credit_target_usd = 0;
     } else {
       payload.kiro_sticky_session_ttl_seconds = normalizeKiroStickySessionTTL(
         payload.kiro_sticky_session_ttl_seconds,

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -705,6 +705,17 @@
             />
             <p class="input-hint">每 credit 最终扣费的 USD（最终价，不再叠加分组/用户倍率或渠道定价）。0 = 禁用反向缩放（按 token × Anthropic 标准价计费）。</p>
           </div>
+          <div v-if="createForm.kiro_cache_emulation_enabled" class="mt-3">
+            <label class="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                :checked="(createForm.kiro_cache_force_ratio_center || 0) > 0"
+                @change="(e) => createForm.kiro_cache_force_ratio_center = (e.target as HTMLInputElement).checked ? 0.925 : 0"
+              />
+              {{ t("admin.groups.kiroCache.forceRatio") }}
+            </label>
+            <p class="input-hint">{{ t("admin.groups.kiroCache.forceRatioHint") }}</p>
+          </div>
         </div>
 
         <div class="border-t pt-4">
@@ -2052,6 +2063,17 @@
               placeholder="0.0000"
             />
             <p class="input-hint">每 credit 最终扣费的 USD（最终价，不再叠加分组/用户倍率或渠道定价）。0 = 禁用反向缩放（按 token × Anthropic 标准价计费）。</p>
+          </div>
+          <div v-if="editForm.kiro_cache_emulation_enabled" class="mt-3">
+            <label class="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                :checked="(editForm.kiro_cache_force_ratio_center || 0) > 0"
+                @change="(e) => editForm.kiro_cache_force_ratio_center = (e.target as HTMLInputElement).checked ? 0.925 : 0"
+              />
+              {{ t("admin.groups.kiroCache.forceRatio") }}
+            </label>
+            <p class="input-hint">{{ t("admin.groups.kiroCache.forceRatioHint") }}</p>
           </div>
         </div>
 
@@ -3509,6 +3531,7 @@ const createForm = reactive({
   kiro_cache_emulation_ratio: 1,
   // Kiro 反向 token 缩放锚定单价（仅 Kiro 平台；0=禁用）
   kiro_credit_target_usd: 0 as number,
+  kiro_cache_force_ratio_center: 0 as number,
 });
 
 // 简单账号类型（用于模型路由选择）
@@ -3848,6 +3871,7 @@ const editForm = reactive({
   kiro_cache_emulation_ratio: 1,
   // Kiro 反向 token 缩放锚定单价（仅 Kiro 平台；0=禁用）
   kiro_credit_target_usd: 0 as number,
+  kiro_cache_force_ratio_center: 0 as number,
 });
 
 type ImagePricingFormState = {
@@ -4090,6 +4114,7 @@ const closeCreateModal = () => {
   createForm.kiro_sticky_session_ttl_seconds = 3600;
   createForm.kiro_cache_emulation_ratio = 1;
   createForm.kiro_credit_target_usd = 0;
+  createForm.kiro_cache_force_ratio_center = 0;
   resetModelsListState(createModelsListState);
   createModelRoutingRules.value = [];
 };
@@ -4185,6 +4210,7 @@ const handleCreateGroup = async () => {
       requestData.kiro_cache_emulation_enabled = false;
       requestData.kiro_cache_emulation_ratio = 0;
       requestData.kiro_credit_target_usd = 0;
+      requestData.kiro_cache_force_ratio_center = 0;
     } else {
       requestData.kiro_sticky_session_ttl_seconds = normalizeKiroStickySessionTTL(
         requestData.kiro_sticky_session_ttl_seconds,
@@ -4260,6 +4286,7 @@ const handleEdit = async (group: AdminGroup) => {
   editForm.kiro_cache_emulation_enabled = group.kiro_cache_emulation_enabled ?? false;
   editForm.kiro_cache_emulation_ratio = group.kiro_cache_emulation_ratio ?? 1;
   editForm.kiro_credit_target_usd = group.kiro_credit_target_usd ?? 0;
+  editForm.kiro_cache_force_ratio_center = group.kiro_cache_force_ratio_center ?? 0;
   resetModelsListState(editModelsListState, group.models_list_config);
   // 加载模型路由规则（异步加载账号名称）
   editModelRoutingRules.value = await convertApiFormatToRoutingRules(
@@ -4342,6 +4369,7 @@ const handleUpdateGroup = async () => {
       payload.kiro_cache_emulation_enabled = false;
       payload.kiro_cache_emulation_ratio = 0;
       payload.kiro_credit_target_usd = 0;
+      payload.kiro_cache_force_ratio_center = 0;
     } else {
       payload.kiro_sticky_session_ttl_seconds = normalizeKiroStickySessionTTL(
         payload.kiro_sticky_session_ttl_seconds,

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -693,7 +693,7 @@
             <p class="input-hint">{{ t("admin.groups.kiroCache.ratioHint") }}</p>
           </div>
           <div class="mt-4">
-            <label class="input-label">Kiro 反向缩放锚定单价（USD/credit）</label>
+            <label class="input-label">Kiro credit 最终单价（USD/credit）</label>
             <input
               v-model.number="createForm.kiro_credit_target_usd"
               type="number"
@@ -703,7 +703,7 @@
               class="input"
               placeholder="0.0000"
             />
-            <p class="input-hint">每 credit 对应的 sub2api USD 余额。0 = 禁用反向缩放（按 token × Anthropic 标准价计费）。</p>
+            <p class="input-hint">每 credit 最终扣费的 USD（最终价，不再叠加分组/用户倍率或渠道定价）。0 = 禁用反向缩放（按 token × Anthropic 标准价计费）。</p>
           </div>
         </div>
 
@@ -2041,7 +2041,7 @@
             <p class="input-hint">{{ t("admin.groups.kiroCache.ratioHint") }}</p>
           </div>
           <div class="mt-4">
-            <label class="input-label">Kiro 反向缩放锚定单价（USD/credit）</label>
+            <label class="input-label">Kiro credit 最终单价（USD/credit）</label>
             <input
               v-model.number="editForm.kiro_credit_target_usd"
               type="number"
@@ -2051,7 +2051,7 @@
               class="input"
               placeholder="0.0000"
             />
-            <p class="input-hint">每 credit 对应的 sub2api USD 余额。0 = 禁用反向缩放（按 token × Anthropic 标准价计费）。</p>
+            <p class="input-hint">每 credit 最终扣费的 USD（最终价，不再叠加分组/用户倍率或渠道定价）。0 = 禁用反向缩放（按 token × Anthropic 标准价计费）。</p>
           </div>
         </div>
 


### PR DESCRIPTION
## 背景
Kiro PRO 账号按 credits 计量（如 12000/月），但 token 数 × Anthropic 标准价 ≠ credit 实际价值，导致用量展示和余额扣费与真实上游消耗严重偏离。本 PR 把 Kiro 计费锚定到 credits，并把展示口径美化成真实 Claude Code 直连的样子。

## 这次改了什么
**计费锚定（核心）**
- group 新增 `kiro_credit_target_usd`（默认 0=禁用）：每 credit **最终**扣费 USD（最终价）。
- translator 解析 `meteringEvent.usage` 累加真实 credits 到 `Usage.KiroCredits`；流式经 SSE `_sub2api_kiro_credits` 内部字段传到计费层，gateway 转发前剥离（客户端不可见，有端到端测试），非流式走 `ParseResult.Usage`。
- **后置覆写**：计费链末端 `applyKiroCreditDirectCost` 把 `ActualCost = total_credits × target_usd`，绕过 group/user rate multiplier 与 channel pricing，确保"配多少扣多少"精确成立（解决 review 提出的 multiplier 二次改写问题）。
- 单请求 credits 上限熔断（500，clamp+ALERT），防上游异常 metering 一次扣巨额。
- 反向缩放 `applyKiroReverseScalingUsage` 按标准价反推 K 缩放 4 个 token 字段（仅决定**展示** token 形状，金额由上面的覆写锚定）。

**展示口径美化**
- group 新增 `kiro_cache_force_ratio_center`（默认 0=禁用）：>0 时把模拟缓存分布重塑成 Anthropic-like 形态（input 极小、cache_read 占大头），拟合表基于真实 Claude Code 直连流量。**因为金额已锚定在 credits 上（见上），此重塑为纯展示，不改变最终扣费。**

**多轮 web search credits**
- web search 每轮各产生 credits，执行层累计全部轮次；流式最后一轮经 `RewriteFinalKiroCredits` 注入累计总额（缺字段也注入，防最后一轮无 metering 时漏计费）。

**持久化 / 缓存**
- `usage_logs.kiro_credits`（新可空列）持久化每请求真实 credits 供对账。
- API key auth 快照版本 bump 至 15（携带 credit target + cache force ratio）。
- migration 153/154/155/156（155 为 `_notx` 非事务建索引）。

## 没有放进这次 PR 的内容
不把 credits 纳入账号调度决策（仅计费侧）。group 级 q/krs endpoint 选择是独立 PR。

## 验证
```
go test ./internal/pkg/kiro -count=1
go test -tags=unit ./internal/service -run 'Kiro|Group|CacheForce|APIKeyAuth|ApplyKiroCreditDirectCost|ReverseScaling' -count=1
cd ../frontend && pnpm typecheck && pnpm lint:check
```
向后兼容：`kiro_credit_target_usd=0` 且 `kiro_cache_force_ratio_center=0`（默认）下行为完全不变；非 kiro 平台字段归一化清空。

## 线上验证建议
给 Kiro 分组配 `kiro_credit_target_usd`（并可开 cache force），warm-up 后看 `usage_logs.kiro_credits` 有值、`actual_cost ≡ kiro_credits × 单价`（group multiplier≠1 也精确成立）；开 cache force 后 input 极小/cache_read 占大头但**最终扣费不变**（=credits×单价）；多轮 web search 时 kiro_credits 为各轮之和；客户端 SSE 不含 `_sub2api_kiro_credits`。
