### PR TITLE
feat(kiro): Anthropic-like cache distribution reshaping for emulation

### DIFF
--- a/backend/ent/group.go
+++ b/backend/ent/group.go
@@ -97,6 +97,8 @@ type Group struct {
 	KiroStickySessionTTLSeconds int `json:"kiro_sticky_session_ttl_seconds,omitempty"`
 	// Kiro 模拟缓存生效比例，范围 0-1（仅 kiro 分组生效）
 	KiroCacheEmulationRatio float64 `json:"kiro_cache_emulation_ratio,omitempty"`
+	// Kiro 缓存强制比例中位数（0=禁用）。>0 时把模拟缓存分布重塑成 Anthropic-like 形态（input 极小、cache_read 占大头），纯展示口径美化，不改变真实计费总额
+	KiroCacheForceRatioCenter float64 `json:"kiro_cache_force_ratio_center,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the GroupQuery when eager-loading is set.
 	Edges        GroupEdges `json:"edges"`
@@ -207,7 +209,7 @@ func (*Group) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case group.FieldIsExclusive, group.FieldAllowImageGeneration, group.FieldImageRateIndependent, group.FieldClaudeCodeOnly, group.FieldModelRoutingEnabled, group.FieldMcpXMLInject, group.FieldAllowMessagesDispatch, group.FieldRequireOauthOnly, group.FieldRequirePrivacySet, group.FieldKiroCacheEmulationEnabled, group.FieldKiroAutoStickyEnabled:
 			values[i] = new(sql.NullBool)
-		case group.FieldRateMultiplier, group.FieldDailyLimitUsd, group.FieldWeeklyLimitUsd, group.FieldMonthlyLimitUsd, group.FieldImageRateMultiplier, group.FieldImagePrice1k, group.FieldImagePrice2k, group.FieldImagePrice4k, group.FieldKiroCacheEmulationRatio:
+		case group.FieldRateMultiplier, group.FieldDailyLimitUsd, group.FieldWeeklyLimitUsd, group.FieldMonthlyLimitUsd, group.FieldImageRateMultiplier, group.FieldImagePrice1k, group.FieldImagePrice2k, group.FieldImagePrice4k, group.FieldKiroCacheEmulationRatio, group.FieldKiroCacheForceRatioCenter:
 			values[i] = new(sql.NullFloat64)
 		case group.FieldID, group.FieldDefaultValidityDays, group.FieldFallbackGroupID, group.FieldFallbackGroupIDOnInvalidRequest, group.FieldSortOrder, group.FieldRpmLimit, group.FieldKiroStickySessionTTLSeconds:
 			values[i] = new(sql.NullInt64)
@@ -488,6 +490,12 @@ func (_m *Group) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.KiroCacheEmulationRatio = value.Float64
 			}
+		case group.FieldKiroCacheForceRatioCenter:
+			if value, ok := values[i].(*sql.NullFloat64); !ok {
+				return fmt.Errorf("unexpected type %T for field kiro_cache_force_ratio_center", values[i])
+			} else if value.Valid {
+				_m.KiroCacheForceRatioCenter = value.Float64
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -700,6 +708,9 @@ func (_m *Group) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("kiro_cache_emulation_ratio=")
 	builder.WriteString(fmt.Sprintf("%v", _m.KiroCacheEmulationRatio))
+	builder.WriteString(", ")
+	builder.WriteString("kiro_cache_force_ratio_center=")
+	builder.WriteString(fmt.Sprintf("%v", _m.KiroCacheForceRatioCenter))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/backend/ent/group/group.go
+++ b/backend/ent/group/group.go
@@ -94,6 +94,8 @@ const (
 	FieldKiroStickySessionTTLSeconds = "kiro_sticky_session_ttl_seconds"
 	// FieldKiroCacheEmulationRatio holds the string denoting the kiro_cache_emulation_ratio field in the database.
 	FieldKiroCacheEmulationRatio = "kiro_cache_emulation_ratio"
+	// FieldKiroCacheForceRatioCenter holds the string denoting the kiro_cache_force_ratio_center field in the database.
+	FieldKiroCacheForceRatioCenter = "kiro_cache_force_ratio_center"
 	// EdgeAPIKeys holds the string denoting the api_keys edge name in mutations.
 	EdgeAPIKeys = "api_keys"
 	// EdgeRedeemCodes holds the string denoting the redeem_codes edge name in mutations.
@@ -208,6 +210,7 @@ var Columns = []string{
 	FieldKiroAutoStickyEnabled,
 	FieldKiroStickySessionTTLSeconds,
 	FieldKiroCacheEmulationRatio,
+	FieldKiroCacheForceRatioCenter,
 }
 
 var (
@@ -303,6 +306,8 @@ var (
 	DefaultKiroStickySessionTTLSeconds int
 	// DefaultKiroCacheEmulationRatio holds the default value on creation for the "kiro_cache_emulation_ratio" field.
 	DefaultKiroCacheEmulationRatio float64
+	// DefaultKiroCacheForceRatioCenter holds the default value on creation for the "kiro_cache_force_ratio_center" field.
+	DefaultKiroCacheForceRatioCenter float64
 )
 
 // OrderOption defines the ordering options for the Group queries.
@@ -486,6 +491,11 @@ func ByKiroStickySessionTTLSeconds(opts ...sql.OrderTermOption) OrderOption {
 // ByKiroCacheEmulationRatio orders the results by the kiro_cache_emulation_ratio field.
 func ByKiroCacheEmulationRatio(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldKiroCacheEmulationRatio, opts...).ToFunc()
+}
+
+// ByKiroCacheForceRatioCenter orders the results by the kiro_cache_force_ratio_center field.
+func ByKiroCacheForceRatioCenter(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldKiroCacheForceRatioCenter, opts...).ToFunc()
 }
 
 // ByAPIKeysCount orders the results by api_keys count.

--- a/backend/ent/group/where.go
+++ b/backend/ent/group/where.go
@@ -230,6 +230,11 @@ func KiroCacheEmulationRatio(v float64) predicate.Group {
 	return predicate.Group(sql.FieldEQ(FieldKiroCacheEmulationRatio, v))
 }
 
+// KiroCacheForceRatioCenter applies equality check predicate on the "kiro_cache_force_ratio_center" field. It's identical to KiroCacheForceRatioCenterEQ.
+func KiroCacheForceRatioCenter(v float64) predicate.Group {
+	return predicate.Group(sql.FieldEQ(FieldKiroCacheForceRatioCenter, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Group {
 	return predicate.Group(sql.FieldEQ(FieldCreatedAt, v))
@@ -1558,6 +1563,46 @@ func KiroCacheEmulationRatioLT(v float64) predicate.Group {
 // KiroCacheEmulationRatioLTE applies the LTE predicate on the "kiro_cache_emulation_ratio" field.
 func KiroCacheEmulationRatioLTE(v float64) predicate.Group {
 	return predicate.Group(sql.FieldLTE(FieldKiroCacheEmulationRatio, v))
+}
+
+// KiroCacheForceRatioCenterEQ applies the EQ predicate on the "kiro_cache_force_ratio_center" field.
+func KiroCacheForceRatioCenterEQ(v float64) predicate.Group {
+	return predicate.Group(sql.FieldEQ(FieldKiroCacheForceRatioCenter, v))
+}
+
+// KiroCacheForceRatioCenterNEQ applies the NEQ predicate on the "kiro_cache_force_ratio_center" field.
+func KiroCacheForceRatioCenterNEQ(v float64) predicate.Group {
+	return predicate.Group(sql.FieldNEQ(FieldKiroCacheForceRatioCenter, v))
+}
+
+// KiroCacheForceRatioCenterIn applies the In predicate on the "kiro_cache_force_ratio_center" field.
+func KiroCacheForceRatioCenterIn(vs ...float64) predicate.Group {
+	return predicate.Group(sql.FieldIn(FieldKiroCacheForceRatioCenter, vs...))
+}
+
+// KiroCacheForceRatioCenterNotIn applies the NotIn predicate on the "kiro_cache_force_ratio_center" field.
+func KiroCacheForceRatioCenterNotIn(vs ...float64) predicate.Group {
+	return predicate.Group(sql.FieldNotIn(FieldKiroCacheForceRatioCenter, vs...))
+}
+
+// KiroCacheForceRatioCenterGT applies the GT predicate on the "kiro_cache_force_ratio_center" field.
+func KiroCacheForceRatioCenterGT(v float64) predicate.Group {
+	return predicate.Group(sql.FieldGT(FieldKiroCacheForceRatioCenter, v))
+}
+
+// KiroCacheForceRatioCenterGTE applies the GTE predicate on the "kiro_cache_force_ratio_center" field.
+func KiroCacheForceRatioCenterGTE(v float64) predicate.Group {
+	return predicate.Group(sql.FieldGTE(FieldKiroCacheForceRatioCenter, v))
+}
+
+// KiroCacheForceRatioCenterLT applies the LT predicate on the "kiro_cache_force_ratio_center" field.
+func KiroCacheForceRatioCenterLT(v float64) predicate.Group {
+	return predicate.Group(sql.FieldLT(FieldKiroCacheForceRatioCenter, v))
+}
+
+// KiroCacheForceRatioCenterLTE applies the LTE predicate on the "kiro_cache_force_ratio_center" field.
+func KiroCacheForceRatioCenterLTE(v float64) predicate.Group {
+	return predicate.Group(sql.FieldLTE(FieldKiroCacheForceRatioCenter, v))
 }
 
 // HasAPIKeys applies the HasEdge predicate on the "api_keys" edge.

--- a/backend/ent/group_create.go
+++ b/backend/ent/group_create.go
@@ -551,6 +551,20 @@ func (_c *GroupCreate) SetNillableKiroCacheEmulationRatio(v *float64) *GroupCrea
 	return _c
 }
 
+// SetKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field.
+func (_c *GroupCreate) SetKiroCacheForceRatioCenter(v float64) *GroupCreate {
+	_c.mutation.SetKiroCacheForceRatioCenter(v)
+	return _c
+}
+
+// SetNillableKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field if the given value is not nil.
+func (_c *GroupCreate) SetNillableKiroCacheForceRatioCenter(v *float64) *GroupCreate {
+	if v != nil {
+		_c.SetKiroCacheForceRatioCenter(*v)
+	}
+	return _c
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by IDs.
 func (_c *GroupCreate) AddAPIKeyIDs(ids ...int64) *GroupCreate {
 	_c.mutation.AddAPIKeyIDs(ids...)
@@ -792,6 +806,10 @@ func (_c *GroupCreate) defaults() error {
 		v := group.DefaultKiroCacheEmulationRatio
 		_c.mutation.SetKiroCacheEmulationRatio(v)
 	}
+	if _, ok := _c.mutation.KiroCacheForceRatioCenter(); !ok {
+		v := group.DefaultKiroCacheForceRatioCenter
+		_c.mutation.SetKiroCacheForceRatioCenter(v)
+	}
 	return nil
 }
 
@@ -905,6 +923,9 @@ func (_c *GroupCreate) check() error {
 	}
 	if _, ok := _c.mutation.KiroCacheEmulationRatio(); !ok {
 		return &ValidationError{Name: "kiro_cache_emulation_ratio", err: errors.New(`ent: missing required field "Group.kiro_cache_emulation_ratio"`)}
+	}
+	if _, ok := _c.mutation.KiroCacheForceRatioCenter(); !ok {
+		return &ValidationError{Name: "kiro_cache_force_ratio_center", err: errors.New(`ent: missing required field "Group.kiro_cache_force_ratio_center"`)}
 	}
 	return nil
 }
@@ -1088,6 +1109,10 @@ func (_c *GroupCreate) createSpec() (*Group, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.KiroCacheEmulationRatio(); ok {
 		_spec.SetField(group.FieldKiroCacheEmulationRatio, field.TypeFloat64, value)
 		_node.KiroCacheEmulationRatio = value
+	}
+	if value, ok := _c.mutation.KiroCacheForceRatioCenter(); ok {
+		_spec.SetField(group.FieldKiroCacheForceRatioCenter, field.TypeFloat64, value)
+		_node.KiroCacheForceRatioCenter = value
 	}
 	if nodes := _c.mutation.APIKeysIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1857,6 +1882,24 @@ func (u *GroupUpsert) AddKiroCacheEmulationRatio(v float64) *GroupUpsert {
 	return u
 }
 
+// SetKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field.
+func (u *GroupUpsert) SetKiroCacheForceRatioCenter(v float64) *GroupUpsert {
+	u.Set(group.FieldKiroCacheForceRatioCenter, v)
+	return u
+}
+
+// UpdateKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field to the value that was provided on create.
+func (u *GroupUpsert) UpdateKiroCacheForceRatioCenter() *GroupUpsert {
+	u.SetExcluded(group.FieldKiroCacheForceRatioCenter)
+	return u
+}
+
+// AddKiroCacheForceRatioCenter adds v to the "kiro_cache_force_ratio_center" field.
+func (u *GroupUpsert) AddKiroCacheForceRatioCenter(v float64) *GroupUpsert {
+	u.Add(group.FieldKiroCacheForceRatioCenter, v)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create.
 // Using this option is equivalent to using:
 //
@@ -2613,6 +2656,27 @@ func (u *GroupUpsertOne) AddKiroCacheEmulationRatio(v float64) *GroupUpsertOne {
 func (u *GroupUpsertOne) UpdateKiroCacheEmulationRatio() *GroupUpsertOne {
 	return u.Update(func(s *GroupUpsert) {
 		s.UpdateKiroCacheEmulationRatio()
+	})
+}
+
+// SetKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field.
+func (u *GroupUpsertOne) SetKiroCacheForceRatioCenter(v float64) *GroupUpsertOne {
+	return u.Update(func(s *GroupUpsert) {
+		s.SetKiroCacheForceRatioCenter(v)
+	})
+}
+
+// AddKiroCacheForceRatioCenter adds v to the "kiro_cache_force_ratio_center" field.
+func (u *GroupUpsertOne) AddKiroCacheForceRatioCenter(v float64) *GroupUpsertOne {
+	return u.Update(func(s *GroupUpsert) {
+		s.AddKiroCacheForceRatioCenter(v)
+	})
+}
+
+// UpdateKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field to the value that was provided on create.
+func (u *GroupUpsertOne) UpdateKiroCacheForceRatioCenter() *GroupUpsertOne {
+	return u.Update(func(s *GroupUpsert) {
+		s.UpdateKiroCacheForceRatioCenter()
 	})
 }
 
@@ -3538,6 +3602,27 @@ func (u *GroupUpsertBulk) AddKiroCacheEmulationRatio(v float64) *GroupUpsertBulk
 func (u *GroupUpsertBulk) UpdateKiroCacheEmulationRatio() *GroupUpsertBulk {
 	return u.Update(func(s *GroupUpsert) {
 		s.UpdateKiroCacheEmulationRatio()
+	})
+}
+
+// SetKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field.
+func (u *GroupUpsertBulk) SetKiroCacheForceRatioCenter(v float64) *GroupUpsertBulk {
+	return u.Update(func(s *GroupUpsert) {
+		s.SetKiroCacheForceRatioCenter(v)
+	})
+}
+
+// AddKiroCacheForceRatioCenter adds v to the "kiro_cache_force_ratio_center" field.
+func (u *GroupUpsertBulk) AddKiroCacheForceRatioCenter(v float64) *GroupUpsertBulk {
+	return u.Update(func(s *GroupUpsert) {
+		s.AddKiroCacheForceRatioCenter(v)
+	})
+}
+
+// UpdateKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field to the value that was provided on create.
+func (u *GroupUpsertBulk) UpdateKiroCacheForceRatioCenter() *GroupUpsertBulk {
+	return u.Update(func(s *GroupUpsert) {
+		s.UpdateKiroCacheForceRatioCenter()
 	})
 }
 

--- a/backend/ent/group_update.go
+++ b/backend/ent/group_update.go
@@ -721,6 +721,27 @@ func (_u *GroupUpdate) AddKiroCacheEmulationRatio(v float64) *GroupUpdate {
 	return _u
 }
 
+// SetKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field.
+func (_u *GroupUpdate) SetKiroCacheForceRatioCenter(v float64) *GroupUpdate {
+	_u.mutation.ResetKiroCacheForceRatioCenter()
+	_u.mutation.SetKiroCacheForceRatioCenter(v)
+	return _u
+}
+
+// SetNillableKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field if the given value is not nil.
+func (_u *GroupUpdate) SetNillableKiroCacheForceRatioCenter(v *float64) *GroupUpdate {
+	if v != nil {
+		_u.SetKiroCacheForceRatioCenter(*v)
+	}
+	return _u
+}
+
+// AddKiroCacheForceRatioCenter adds value to the "kiro_cache_force_ratio_center" field.
+func (_u *GroupUpdate) AddKiroCacheForceRatioCenter(v float64) *GroupUpdate {
+	_u.mutation.AddKiroCacheForceRatioCenter(v)
+	return _u
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by IDs.
 func (_u *GroupUpdate) AddAPIKeyIDs(ids ...int64) *GroupUpdate {
 	_u.mutation.AddAPIKeyIDs(ids...)
@@ -1222,6 +1243,12 @@ func (_u *GroupUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.AddedKiroCacheEmulationRatio(); ok {
 		_spec.AddField(group.FieldKiroCacheEmulationRatio, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.KiroCacheForceRatioCenter(); ok {
+		_spec.SetField(group.FieldKiroCacheForceRatioCenter, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.AddedKiroCacheForceRatioCenter(); ok {
+		_spec.AddField(group.FieldKiroCacheForceRatioCenter, field.TypeFloat64, value)
 	}
 	if _u.mutation.APIKeysCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -2222,6 +2249,27 @@ func (_u *GroupUpdateOne) AddKiroCacheEmulationRatio(v float64) *GroupUpdateOne 
 	return _u
 }
 
+// SetKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field.
+func (_u *GroupUpdateOne) SetKiroCacheForceRatioCenter(v float64) *GroupUpdateOne {
+	_u.mutation.ResetKiroCacheForceRatioCenter()
+	_u.mutation.SetKiroCacheForceRatioCenter(v)
+	return _u
+}
+
+// SetNillableKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field if the given value is not nil.
+func (_u *GroupUpdateOne) SetNillableKiroCacheForceRatioCenter(v *float64) *GroupUpdateOne {
+	if v != nil {
+		_u.SetKiroCacheForceRatioCenter(*v)
+	}
+	return _u
+}
+
+// AddKiroCacheForceRatioCenter adds value to the "kiro_cache_force_ratio_center" field.
+func (_u *GroupUpdateOne) AddKiroCacheForceRatioCenter(v float64) *GroupUpdateOne {
+	_u.mutation.AddKiroCacheForceRatioCenter(v)
+	return _u
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by IDs.
 func (_u *GroupUpdateOne) AddAPIKeyIDs(ids ...int64) *GroupUpdateOne {
 	_u.mutation.AddAPIKeyIDs(ids...)
@@ -2753,6 +2801,12 @@ func (_u *GroupUpdateOne) sqlSave(ctx context.Context) (_node *Group, err error)
 	}
 	if value, ok := _u.mutation.AddedKiroCacheEmulationRatio(); ok {
 		_spec.AddField(group.FieldKiroCacheEmulationRatio, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.KiroCacheForceRatioCenter(); ok {
+		_spec.SetField(group.FieldKiroCacheForceRatioCenter, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.AddedKiroCacheForceRatioCenter(); ok {
+		_spec.AddField(group.FieldKiroCacheForceRatioCenter, field.TypeFloat64, value)
 	}
 	if _u.mutation.APIKeysCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -676,6 +676,7 @@ var (
 		{Name: "kiro_auto_sticky_enabled", Type: field.TypeBool, Default: true},
 		{Name: "kiro_sticky_session_ttl_seconds", Type: field.TypeInt, Default: 3600},
 		{Name: "kiro_cache_emulation_ratio", Type: field.TypeFloat64, Default: 1, SchemaType: map[string]string{"postgres": "decimal(5,4)"}},
+		{Name: "kiro_cache_force_ratio_center", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "decimal(5,4)"}},
 	}
 	// GroupsTable holds the schema information for the "groups" table.
 	GroupsTable = &schema.Table{

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -15017,6 +15017,8 @@ type GroupMutation struct {
 	addkiro_sticky_session_ttl_seconds      *int
 	kiro_cache_emulation_ratio              *float64
 	addkiro_cache_emulation_ratio           *float64
+	kiro_cache_force_ratio_center           *float64
+	addkiro_cache_force_ratio_center        *float64
 	clearedFields                           map[string]struct{}
 	api_keys                                map[int64]struct{}
 	removedapi_keys                         map[int64]struct{}
@@ -17009,6 +17011,62 @@ func (m *GroupMutation) ResetKiroCacheEmulationRatio() {
 	m.addkiro_cache_emulation_ratio = nil
 }
 
+// SetKiroCacheForceRatioCenter sets the "kiro_cache_force_ratio_center" field.
+func (m *GroupMutation) SetKiroCacheForceRatioCenter(f float64) {
+	m.kiro_cache_force_ratio_center = &f
+	m.addkiro_cache_force_ratio_center = nil
+}
+
+// KiroCacheForceRatioCenter returns the value of the "kiro_cache_force_ratio_center" field in the mutation.
+func (m *GroupMutation) KiroCacheForceRatioCenter() (r float64, exists bool) {
+	v := m.kiro_cache_force_ratio_center
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldKiroCacheForceRatioCenter returns the old "kiro_cache_force_ratio_center" field's value of the Group entity.
+// If the Group object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *GroupMutation) OldKiroCacheForceRatioCenter(ctx context.Context) (v float64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldKiroCacheForceRatioCenter is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldKiroCacheForceRatioCenter requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldKiroCacheForceRatioCenter: %w", err)
+	}
+	return oldValue.KiroCacheForceRatioCenter, nil
+}
+
+// AddKiroCacheForceRatioCenter adds f to the "kiro_cache_force_ratio_center" field.
+func (m *GroupMutation) AddKiroCacheForceRatioCenter(f float64) {
+	if m.addkiro_cache_force_ratio_center != nil {
+		*m.addkiro_cache_force_ratio_center += f
+	} else {
+		m.addkiro_cache_force_ratio_center = &f
+	}
+}
+
+// AddedKiroCacheForceRatioCenter returns the value that was added to the "kiro_cache_force_ratio_center" field in this mutation.
+func (m *GroupMutation) AddedKiroCacheForceRatioCenter() (r float64, exists bool) {
+	v := m.addkiro_cache_force_ratio_center
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetKiroCacheForceRatioCenter resets all changes to the "kiro_cache_force_ratio_center" field.
+func (m *GroupMutation) ResetKiroCacheForceRatioCenter() {
+	m.kiro_cache_force_ratio_center = nil
+	m.addkiro_cache_force_ratio_center = nil
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by ids.
 func (m *GroupMutation) AddAPIKeyIDs(ids ...int64) {
 	if m.api_keys == nil {
@@ -17367,7 +17425,7 @@ func (m *GroupMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *GroupMutation) Fields() []string {
-	fields := make([]string, 0, 39)
+	fields := make([]string, 0, 40)
 	if m.created_at != nil {
 		fields = append(fields, group.FieldCreatedAt)
 	}
@@ -17485,6 +17543,9 @@ func (m *GroupMutation) Fields() []string {
 	if m.kiro_cache_emulation_ratio != nil {
 		fields = append(fields, group.FieldKiroCacheEmulationRatio)
 	}
+	if m.kiro_cache_force_ratio_center != nil {
+		fields = append(fields, group.FieldKiroCacheForceRatioCenter)
+	}
 	return fields
 }
 
@@ -17571,6 +17632,8 @@ func (m *GroupMutation) Field(name string) (ent.Value, bool) {
 		return m.KiroStickySessionTTLSeconds()
 	case group.FieldKiroCacheEmulationRatio:
 		return m.KiroCacheEmulationRatio()
+	case group.FieldKiroCacheForceRatioCenter:
+		return m.KiroCacheForceRatioCenter()
 	}
 	return nil, false
 }
@@ -17658,6 +17721,8 @@ func (m *GroupMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldKiroStickySessionTTLSeconds(ctx)
 	case group.FieldKiroCacheEmulationRatio:
 		return m.OldKiroCacheEmulationRatio(ctx)
+	case group.FieldKiroCacheForceRatioCenter:
+		return m.OldKiroCacheForceRatioCenter(ctx)
 	}
 	return nil, fmt.Errorf("unknown Group field %s", name)
 }
@@ -17940,6 +18005,13 @@ func (m *GroupMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetKiroCacheEmulationRatio(v)
 		return nil
+	case group.FieldKiroCacheForceRatioCenter:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetKiroCacheForceRatioCenter(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Group field %s", name)
 }
@@ -17993,6 +18065,9 @@ func (m *GroupMutation) AddedFields() []string {
 	if m.addkiro_cache_emulation_ratio != nil {
 		fields = append(fields, group.FieldKiroCacheEmulationRatio)
 	}
+	if m.addkiro_cache_force_ratio_center != nil {
+		fields = append(fields, group.FieldKiroCacheForceRatioCenter)
+	}
 	return fields
 }
 
@@ -18031,6 +18106,8 @@ func (m *GroupMutation) AddedField(name string) (ent.Value, bool) {
 		return m.AddedKiroStickySessionTTLSeconds()
 	case group.FieldKiroCacheEmulationRatio:
 		return m.AddedKiroCacheEmulationRatio()
+	case group.FieldKiroCacheForceRatioCenter:
+		return m.AddedKiroCacheForceRatioCenter()
 	}
 	return nil, false
 }
@@ -18144,6 +18221,13 @@ func (m *GroupMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddKiroCacheEmulationRatio(v)
+		return nil
+	case group.FieldKiroCacheForceRatioCenter:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddKiroCacheForceRatioCenter(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Group numeric field %s", name)
@@ -18357,6 +18441,9 @@ func (m *GroupMutation) ResetField(name string) error {
 		return nil
 	case group.FieldKiroCacheEmulationRatio:
 		m.ResetKiroCacheEmulationRatio()
+		return nil
+	case group.FieldKiroCacheForceRatioCenter:
+		m.ResetKiroCacheForceRatioCenter()
 		return nil
 	}
 	return fmt.Errorf("unknown Group field %s", name)

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -894,6 +894,10 @@ func init() {
 	groupDescKiroCacheEmulationRatio := groupFields[35].Descriptor()
 	// group.DefaultKiroCacheEmulationRatio holds the default value on creation for the kiro_cache_emulation_ratio field.
 	group.DefaultKiroCacheEmulationRatio = groupDescKiroCacheEmulationRatio.Default.(float64)
+	// groupDescKiroCacheForceRatioCenter is the schema descriptor for kiro_cache_force_ratio_center field.
+	groupDescKiroCacheForceRatioCenter := groupFields[36].Descriptor()
+	// group.DefaultKiroCacheForceRatioCenter holds the default value on creation for the kiro_cache_force_ratio_center field.
+	group.DefaultKiroCacheForceRatioCenter = groupDescKiroCacheForceRatioCenter.Default.(float64)
 	idempotencyrecordMixin := schema.IdempotencyRecord{}.Mixin()
 	idempotencyrecordMixinFields0 := idempotencyrecordMixin[0].Fields()
 	_ = idempotencyrecordMixinFields0

--- a/backend/ent/schema/group.go
+++ b/backend/ent/schema/group.go
@@ -179,6 +179,10 @@ func (Group) Fields() []ent.Field {
 			SchemaType(map[string]string{dialect.Postgres: "decimal(5,4)"}).
 			Default(1.0).
 			Comment("Kiro 模拟缓存生效比例，范围 0-1（仅 kiro 分组生效）"),
+		field.Float("kiro_cache_force_ratio_center").
+			SchemaType(map[string]string{dialect.Postgres: "decimal(5,4)"}).
+			Default(0).
+			Comment("Kiro 缓存强制比例中位数（0=禁用）。>0 时把模拟缓存分布重塑成 Anthropic-like 形态（input 极小、cache_read 占大头），纯展示口径美化，不改变真实计费总额"),
 	}
 }
 

--- a/backend/internal/handler/admin/group_handler.go
+++ b/backend/internal/handler/admin/group_handler.go
@@ -121,6 +121,7 @@ type CreateGroupRequest struct {
 	KiroAutoStickyEnabled       *bool    `json:"kiro_auto_sticky_enabled"`
 	KiroStickySessionTTLSeconds *int     `json:"kiro_sticky_session_ttl_seconds"`
 	KiroCacheEmulationRatio     *float64 `json:"kiro_cache_emulation_ratio"`
+	KiroCacheForceRatioCenter   *float64 `json:"kiro_cache_force_ratio_center"`
 	// 从指定分组复制账号（创建后自动绑定）
 	CopyAccountsFromGroupIDs []int64 `json:"copy_accounts_from_group_ids"`
 }
@@ -167,6 +168,7 @@ type UpdateGroupRequest struct {
 	KiroAutoStickyEnabled       *bool    `json:"kiro_auto_sticky_enabled"`
 	KiroStickySessionTTLSeconds *int     `json:"kiro_sticky_session_ttl_seconds"`
 	KiroCacheEmulationRatio     *float64 `json:"kiro_cache_emulation_ratio"`
+	KiroCacheForceRatioCenter   *float64 `json:"kiro_cache_force_ratio_center"`
 	// 从指定分组复制账号（同步操作：先清空当前分组的账号绑定，再绑定源分组的账号）
 	CopyAccountsFromGroupIDs []int64 `json:"copy_accounts_from_group_ids"`
 }
@@ -321,6 +323,7 @@ func (h *GroupHandler) Create(c *gin.Context) {
 		KiroAutoStickyEnabled:           req.KiroAutoStickyEnabled,
 		KiroStickySessionTTLSeconds:     req.KiroStickySessionTTLSeconds,
 		KiroCacheEmulationRatio:         req.KiroCacheEmulationRatio,
+		KiroCacheForceRatioCenter:       req.KiroCacheForceRatioCenter,
 		CopyAccountsFromGroupIDs:        req.CopyAccountsFromGroupIDs,
 	})
 	if err != nil {
@@ -381,6 +384,7 @@ func (h *GroupHandler) Update(c *gin.Context) {
 		KiroAutoStickyEnabled:           req.KiroAutoStickyEnabled,
 		KiroStickySessionTTLSeconds:     req.KiroStickySessionTTLSeconds,
 		KiroCacheEmulationRatio:         req.KiroCacheEmulationRatio,
+		KiroCacheForceRatioCenter:       req.KiroCacheForceRatioCenter,
 		CopyAccountsFromGroupIDs:        req.CopyAccountsFromGroupIDs,
 	})
 	if err != nil {

--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -195,6 +195,7 @@ func groupFromServiceBase(g *service.Group) Group {
 		KiroAutoStickyEnabled:           g.EffectiveKiroAutoStickyEnabled(),
 		KiroStickySessionTTLSeconds:     g.EffectiveKiroStickySessionTTLSeconds(),
 		KiroCacheEmulationRatio:         g.EffectiveKiroCacheEmulationRatio(),
+		KiroCacheForceRatioCenter:       g.EffectiveKiroCacheForceRatioCenter(),
 		CreatedAt:                       g.CreatedAt,
 		UpdatedAt:                       g.UpdatedAt,
 	}

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -125,6 +125,7 @@ type Group struct {
 	KiroAutoStickyEnabled       bool    `json:"kiro_auto_sticky_enabled"`
 	KiroStickySessionTTLSeconds int     `json:"kiro_sticky_session_ttl_seconds"`
 	KiroCacheEmulationRatio     float64 `json:"kiro_cache_emulation_ratio"`
+	KiroCacheForceRatioCenter   float64 `json:"kiro_cache_force_ratio_center"`
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`

--- a/backend/internal/repository/api_key_repo.go
+++ b/backend/internal/repository/api_key_repo.go
@@ -818,6 +818,7 @@ func groupEntityToService(g *dbent.Group) *service.Group {
 		KiroAutoStickyEnabled:           g.KiroAutoStickyEnabled,
 		KiroStickySessionTTLSeconds:     g.KiroStickySessionTTLSeconds,
 		KiroCacheEmulationRatio:         g.KiroCacheEmulationRatio,
+		KiroCacheForceRatioCenter:       g.KiroCacheForceRatioCenter,
 		CreatedAt:                       g.CreatedAt,
 		UpdatedAt:                       g.UpdatedAt,
 	}

--- a/backend/internal/repository/group_repo.go
+++ b/backend/internal/repository/group_repo.go
@@ -72,7 +72,8 @@ func (r *groupRepository) Create(ctx context.Context, groupIn *service.Group) er
 		SetKiroCacheEmulationEnabled(groupIn.KiroCacheEmulationEnabled).
 		SetKiroAutoStickyEnabled(groupIn.KiroAutoStickyEnabled).
 		SetKiroStickySessionTTLSeconds(groupIn.KiroStickySessionTTLSeconds).
-		SetKiroCacheEmulationRatio(groupIn.KiroCacheEmulationRatio)
+		SetKiroCacheEmulationRatio(groupIn.KiroCacheEmulationRatio).
+		SetKiroCacheForceRatioCenter(groupIn.KiroCacheForceRatioCenter)
 
 	// 设置模型路由配置
 	if groupIn.ModelRouting != nil {
@@ -153,7 +154,8 @@ func (r *groupRepository) Update(ctx context.Context, groupIn *service.Group) er
 		SetKiroCacheEmulationEnabled(groupIn.KiroCacheEmulationEnabled).
 		SetKiroAutoStickyEnabled(groupIn.KiroAutoStickyEnabled).
 		SetKiroStickySessionTTLSeconds(groupIn.KiroStickySessionTTLSeconds).
-		SetKiroCacheEmulationRatio(groupIn.KiroCacheEmulationRatio)
+		SetKiroCacheEmulationRatio(groupIn.KiroCacheEmulationRatio).
+		SetKiroCacheForceRatioCenter(groupIn.KiroCacheForceRatioCenter)
 
 	// 显式处理可空字段：nil 需要 clear，非 nil 需要 set。
 	if groupIn.DailyLimitUSD != nil {

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -235,6 +235,7 @@ type CreateGroupInput struct {
 	KiroAutoStickyEnabled       *bool
 	KiroStickySessionTTLSeconds *int
 	KiroCacheEmulationRatio     *float64
+	KiroCacheForceRatioCenter   *float64
 	// 从指定分组复制账号（创建分组后在同一事务内绑定）
 	CopyAccountsFromGroupIDs []int64
 }
@@ -281,6 +282,7 @@ type UpdateGroupInput struct {
 	KiroAutoStickyEnabled       *bool
 	KiroStickySessionTTLSeconds *int
 	KiroCacheEmulationRatio     *float64
+	KiroCacheForceRatioCenter   *float64
 	// 从指定分组复制账号（同步操作：先清空当前分组的账号绑定，再绑定源分组的账号）
 	CopyAccountsFromGroupIDs []int64
 }
@@ -1930,8 +1932,12 @@ func (s *adminServiceImpl) CreateGroup(ctx context.Context, input *CreateGroupIn
 	if input.KiroCacheEmulationRatio != nil {
 		group.KiroCacheEmulationRatio = *input.KiroCacheEmulationRatio
 	}
+	if input.KiroCacheForceRatioCenter != nil {
+		group.KiroCacheForceRatioCenter = *input.KiroCacheForceRatioCenter
+	}
 	sanitizeGroupMessagesDispatchFields(group)
 	normalizeKiroCacheEmulationFields(group)
+	normalizeKiroCacheForceFields(group)
 	if err := s.groupRepo.Create(ctx, group); err != nil {
 		return nil, err
 	}
@@ -2194,8 +2200,12 @@ func (s *adminServiceImpl) UpdateGroup(ctx context.Context, id int64, input *Upd
 	if input.KiroCacheEmulationRatio != nil {
 		group.KiroCacheEmulationRatio = *input.KiroCacheEmulationRatio
 	}
+	if input.KiroCacheForceRatioCenter != nil {
+		group.KiroCacheForceRatioCenter = *input.KiroCacheForceRatioCenter
+	}
 	sanitizeGroupMessagesDispatchFields(group)
 	normalizeKiroCacheEmulationFields(group)
+	normalizeKiroCacheForceFields(group)
 
 	if err := s.groupRepo.Update(ctx, group); err != nil {
 		return nil, err

--- a/backend/internal/service/api_key_auth_cache.go
+++ b/backend/internal/service/api_key_auth_cache.go
@@ -99,6 +99,7 @@ type APIKeyAuthGroupSnapshot struct {
 	KiroAutoStickyEnabled       bool    `json:"kiro_auto_sticky_enabled"`
 	KiroStickySessionTTLSeconds int     `json:"kiro_sticky_session_ttl_seconds"`
 	KiroCacheEmulationRatio     float64 `json:"kiro_cache_emulation_ratio"`
+	KiroCacheForceRatioCenter   float64 `json:"kiro_cache_force_ratio_center"`
 }
 
 // APIKeyAuthCacheEntry 缓存条目，支持负缓存

--- a/backend/internal/service/api_key_auth_cache_impl.go
+++ b/backend/internal/service/api_key_auth_cache_impl.go
@@ -14,7 +14,7 @@ import (
 	"github.com/dgraph-io/ristretto"
 )
 
-const apiKeyAuthSnapshotVersion = 13 // v13: reload snapshots for Kiro auto sticky routing switch
+const apiKeyAuthSnapshotVersion = 14 // v14: carry Kiro cache force ratio center in snapshot
 
 type apiKeyAuthCacheConfig struct {
 	l1Size        int
@@ -286,6 +286,7 @@ func (s *APIKeyService) snapshotFromAPIKey(ctx context.Context, apiKey *APIKey) 
 			KiroAutoStickyEnabled:           groupForSnapshot.EffectiveKiroAutoStickyEnabled(),
 			KiroStickySessionTTLSeconds:     groupForSnapshot.EffectiveKiroStickySessionTTLSeconds(),
 			KiroCacheEmulationRatio:         groupForSnapshot.EffectiveKiroCacheEmulationRatio(),
+			KiroCacheForceRatioCenter:       groupForSnapshot.EffectiveKiroCacheForceRatioCenter(),
 		}
 	}
 	return snapshot
@@ -363,8 +364,10 @@ func (s *APIKeyService) snapshotToAPIKey(key string, snapshot *APIKeyAuthSnapsho
 			KiroAutoStickyEnabled:           snapshot.Group.KiroAutoStickyEnabled,
 			KiroStickySessionTTLSeconds:     snapshot.Group.KiroStickySessionTTLSeconds,
 			KiroCacheEmulationRatio:         snapshot.Group.KiroCacheEmulationRatio,
+			KiroCacheForceRatioCenter:       snapshot.Group.KiroCacheForceRatioCenter,
 		}
 		normalizeKiroCacheEmulationFields(apiKey.Group)
+		normalizeKiroCacheForceFields(apiKey.Group)
 	}
 	s.compileAPIKeyIPRules(apiKey)
 	return apiKey

--- a/backend/internal/service/group.go
+++ b/backend/internal/service/group.go
@@ -74,6 +74,11 @@ type Group struct {
 	KiroStickySessionTTLSeconds int
 	KiroCacheEmulationRatio     float64
 
+	// Kiro 缓存强制比例中位数（仅 platform=kiro 生效）。
+	// 0 = 禁用；> 0 时把模拟缓存分布重塑成 Anthropic-like 形态（input 极小、
+	// cache_read 占大头），纯展示口径美化，不改变真实计费总额。
+	KiroCacheForceRatioCenter float64
+
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
@@ -163,8 +168,49 @@ func normalizeKiroCacheEmulationFields(g *Group) {
 	g.KiroCacheEmulationRatio = normalizeKiroCacheEmulationRatio(g.KiroCacheEmulationRatio)
 }
 
+// kiroCacheForceRatioCenterMaxCap 是 KiroCacheForceRatioCenter 的安全上限。
+const kiroCacheForceRatioCenterMaxCap = 0.99
+
+// EffectiveKiroCacheForceRatioCenter 返回当前 group 实际使用的缓存强制比例中位数。
+// 仅当 Platform = kiro 且配置 > 0 时返回该值（含上限 cap），否则返回 0。
+func (g *Group) EffectiveKiroCacheForceRatioCenter() float64 {
+	if g == nil || g.Platform != PlatformKiro {
+		return 0
+	}
+	v := g.KiroCacheForceRatioCenter
+	if v <= 0 {
+		return 0
+	}
+	if v > kiroCacheForceRatioCenterMaxCap {
+		return kiroCacheForceRatioCenterMaxCap
+	}
+	return v
+}
+
+// KiroCacheForceEnabled 报告该 group 是否启用了缓存分布强制重塑。
+func (g *Group) KiroCacheForceEnabled() bool {
+	return g.EffectiveKiroCacheForceRatioCenter() > 0
+}
+
+func normalizeKiroCacheForceFields(g *Group) {
+	if g == nil {
+		return
+	}
+	if g.Platform != PlatformKiro {
+		g.KiroCacheForceRatioCenter = 0
+		return
+	}
+	if g.KiroCacheForceRatioCenter < 0 {
+		g.KiroCacheForceRatioCenter = 0
+	}
+	if g.KiroCacheForceRatioCenter > kiroCacheForceRatioCenterMaxCap {
+		g.KiroCacheForceRatioCenter = kiroCacheForceRatioCenterMaxCap
+	}
+}
+
 func NormalizeGroupRuntimeFields(g *Group) {
 	normalizeKiroCacheEmulationFields(g)
+	normalizeKiroCacheForceFields(g)
 }
 
 func (g *Group) IsActive() bool {

--- a/backend/internal/service/kiro_cache_emulation.go
+++ b/backend/internal/service/kiro_cache_emulation.go
@@ -77,7 +77,98 @@ func (s *GatewayService) buildKiroCacheEmulationUsage(account *Account, group *G
 	if result.CacheReadInputTokens == 0 && result.CacheCreationInputTokens == 0 {
 		return nil
 	}
+	// 缓存分布强制重塑：把模拟出的 input/cache_read/cache_creation 拆分重塑成
+	// Anthropic-like 形态（input 极小、cache_read 占大头），仅展示口径，不改总额。
+	if group.KiroCacheForceEnabled() {
+		applyKiroCacheForceRatio(result)
+	}
 	return result
+}
+
+// kiroCacheForceBreakpoint 是 Anthropic-like 缓存分布拟合段端点。
+type kiroCacheForceBreakpoint struct {
+	threshold float64
+	readRatio float64
+	inputCap  int
+}
+
+// kiroCacheForceFit 基于真实 Anthropic Claude Code 直连流量反推的分段拟合表：
+// 实测（按 total_input 分桶）input 不随 total 增长（≥20k 恒 p50≈2，故 inputCap=1，
+// 配合下游可能的缩放落到 ~2），cache_read 占比在 0.82~0.93 之间。
+var kiroCacheForceFit = []kiroCacheForceBreakpoint{
+	{0, 0.600, 1},
+	{5000, 0.800, 1},
+	{20000, 0.830, 1},
+	{100000, 0.900, 1},
+	{500000, 0.930, 1},
+	{2000000, 0.915, 1},
+}
+
+// computeKiroCacheForceRatio 给定 total_input_tokens，返回 (cache_read_ratio, input_cap)。
+func computeKiroCacheForceRatio(total int) (float64, int) {
+	t := float64(total)
+	bp := kiroCacheForceFit
+	if t <= bp[0].threshold {
+		return bp[0].readRatio, bp[0].inputCap
+	}
+	if t >= bp[len(bp)-1].threshold {
+		return bp[len(bp)-1].readRatio, bp[len(bp)-1].inputCap
+	}
+	for i := 0; i < len(bp)-1; i++ {
+		if t >= bp[i].threshold && t < bp[i+1].threshold {
+			seg := bp[i+1].threshold - bp[i].threshold
+			if seg <= 0 {
+				return bp[i].readRatio, bp[i].inputCap
+			}
+			p := (t - bp[i].threshold) / seg
+			ratio := bp[i].readRatio + p*(bp[i+1].readRatio-bp[i].readRatio)
+			cap := bp[i].inputCap
+			if bp[i+1].inputCap > cap {
+				cap = bp[i+1].inputCap
+			}
+			return ratio, cap
+		}
+	}
+	return bp[len(bp)-1].readRatio, bp[len(bp)-1].inputCap
+}
+
+// applyKiroCacheForceRatio 把模拟缓存分布重塑成 Anthropic-like：input 钳到极小，
+// 剩余按 readRatio 切给 cache_read / cache_creation；总量守恒。
+func applyKiroCacheForceRatio(u *kiroCacheEmulationUsage) {
+	if u == nil {
+		return
+	}
+	total := u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
+	// 极短请求：只兜底 input=0 → 1。
+	if total <= 100 {
+		if u.InputTokens == 0 && (u.CacheReadInputTokens > 0 || u.CacheCreationInputTokens > 0) {
+			u.InputTokens = 1
+		}
+		return
+	}
+	readRatio, inputCap := computeKiroCacheForceRatio(total)
+	newInput := inputCap
+	if newInput >= total-2 {
+		newInput = total - 2
+	}
+	if newInput < 1 {
+		newInput = 1
+	}
+	remaining := total - newInput
+	newCacheRead := int(math.Round(float64(remaining) * readRatio))
+	if newCacheRead >= remaining {
+		newCacheRead = remaining - 1
+	}
+	if newCacheRead < 0 {
+		newCacheRead = 0
+	}
+	newCacheCreation := remaining - newCacheRead
+	u.InputTokens = newInput
+	u.CacheReadInputTokens = newCacheRead
+	// 真实数据显示 cache_creation 几乎全在 5m TTL。
+	u.CacheCreation5mInputTokens = newCacheCreation
+	u.CacheCreation1hInputTokens = 0
+	u.CacheCreationInputTokens = newCacheCreation
 }
 
 func scaleKiroCacheTokens(tokens int, ratio float64) int {

--- a/backend/internal/service/kiro_cache_force_test.go
+++ b/backend/internal/service/kiro_cache_force_test.go
@@ -1,0 +1,48 @@
+//go:build unit
+
+package service
+
+import "testing"
+
+// TestApplyKiroCacheForceRatio_ReshapesDistribution 验证强制重塑把分布变成
+// Anthropic-like：input 极小、cache_read 占大头，且总量守恒。
+func TestApplyKiroCacheForceRatio_ReshapesDistribution(t *testing.T) {
+	u := &kiroCacheEmulationUsage{InputTokens: 50000, CacheReadInputTokens: 0, CacheCreationInputTokens: 0}
+	applyKiroCacheForceRatio(u)
+
+	total := u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
+	if total != 50000 {
+		t.Fatalf("总量必须守恒，got %d", total)
+	}
+	if u.InputTokens >= 100 {
+		t.Fatalf("input 应被压到极小，got %d", u.InputTokens)
+	}
+	if u.CacheReadInputTokens <= u.CacheCreationInputTokens {
+		t.Fatalf("cache_read 应占大头：cr=%d cc=%d", u.CacheReadInputTokens, u.CacheCreationInputTokens)
+	}
+	if u.CacheCreation5mInputTokens != u.CacheCreationInputTokens {
+		t.Fatalf("cache_creation 应归到 5m TTL")
+	}
+}
+
+// TestApplyKiroCacheForceRatio_ShortRequest 验证极短请求只兜底 input=0->1。
+func TestApplyKiroCacheForceRatio_ShortRequest(t *testing.T) {
+	u := &kiroCacheEmulationUsage{InputTokens: 0, CacheReadInputTokens: 30}
+	applyKiroCacheForceRatio(u)
+	if u.InputTokens != 1 || u.CacheReadInputTokens != 30 {
+		t.Fatalf("极短请求应只兜底 input=1，got input=%d cr=%d", u.InputTokens, u.CacheReadInputTokens)
+	}
+}
+
+// TestEffectiveKiroCacheForceRatioCenter 验证取值/兜底/cap。
+func TestEffectiveKiroCacheForceRatioCenter(t *testing.T) {
+	if v := (&Group{Platform: PlatformKiro, KiroCacheForceRatioCenter: 0.925}).EffectiveKiroCacheForceRatioCenter(); v != 0.925 {
+		t.Fatalf("want 0.925, got %v", v)
+	}
+	if v := (&Group{Platform: PlatformAnthropic, KiroCacheForceRatioCenter: 0.925}).EffectiveKiroCacheForceRatioCenter(); v != 0 {
+		t.Fatalf("非 kiro 平台应返回 0, got %v", v)
+	}
+	if v := (&Group{Platform: PlatformKiro, KiroCacheForceRatioCenter: 2}).EffectiveKiroCacheForceRatioCenter(); v != kiroCacheForceRatioCenterMaxCap {
+		t.Fatalf("超 cap 应被钳到 %v, got %v", kiroCacheForceRatioCenterMaxCap, v)
+	}
+}

--- a/backend/migrations/153_add_group_kiro_cache_force_ratio_center.sql
+++ b/backend/migrations/153_add_group_kiro_cache_force_ratio_center.sql
@@ -1,0 +1,6 @@
+-- Kiro group-level cache-distribution reshaping center.
+-- 0 = disabled (default, backfills existing rows). > 0 reshapes the emulated
+-- cache split into an Anthropic-like distribution (tiny input, cache_read
+-- dominant) for display realism only; it does not change billed totals.
+ALTER TABLE groups
+    ADD COLUMN IF NOT EXISTS kiro_cache_force_ratio_center DECIMAL(5,4) NOT NULL DEFAULT 0;

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2241,6 +2241,8 @@ export default {
         enabled: 'Enable cache emulation',
         ratio: 'Cache ratio',
         ratioHint: '0 to 1. For example, 0.5 applies half of the simulated cache tokens.',
+        forceRatio: 'Enable Anthropic-like cache distribution',
+        forceRatioHint: 'Reshapes the displayed token distribution to match real Anthropic direct usage (tiny input, cache_read dominant). Display only; does not change the real billed total.',
         stickyRouting: 'Enable Kiro account sticky routing',
         stickyRoutingHint: 'When enabled, multi-turn conversations are pinned to the same account when possible. X-Session-ID still takes precedence for explicit session binding.',
         stickyTTL: 'Sticky binding TTL (seconds)',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2324,6 +2324,8 @@ export default {
         enabled: '启用模拟缓存',
         ratio: '缓存比例',
         ratioHint: '范围 0 到 1，例如 0.5 表示只生效一半模拟缓存 token。',
+        forceRatio: '启用 Anthropic-like 缓存分布模拟',
+        forceRatioHint: '把 token 按真实 Anthropic 直连分布重写显示口径（input 极小、cache_read 占大头）；仅展示美化，不改变真实计费总额。',
         stickyRouting: '启用 Kiro 账号粘性路由',
         stickyRoutingHint: '开启后，同一会话的多轮对话会尽量固定到同一账号；请求头传 X-Session-ID 时仍优先使用显式会话绑定。',
         stickyTTL: '粘性绑定时长（秒）',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -532,6 +532,7 @@ export interface Group {
   kiro_sticky_session_ttl_seconds: number
   kiro_cache_emulation_enabled: boolean
   kiro_cache_emulation_ratio: number
+  kiro_cache_force_ratio_center?: number
   created_at: string
   updated_at: string
 }
@@ -658,6 +659,7 @@ export interface CreateGroupRequest {
   kiro_sticky_session_ttl_seconds?: number
   kiro_cache_emulation_enabled?: boolean
   kiro_cache_emulation_ratio?: number
+  kiro_cache_force_ratio_center?: number
   // 从指定分组复制账号
   copy_accounts_from_group_ids?: number[]
 }
@@ -697,6 +699,7 @@ export interface UpdateGroupRequest {
   kiro_sticky_session_ttl_seconds?: number
   kiro_cache_emulation_enabled?: boolean
   kiro_cache_emulation_ratio?: number
+  kiro_cache_force_ratio_center?: number
   copy_accounts_from_group_ids?: number[]
 }
 

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -692,6 +692,17 @@
             />
             <p class="input-hint">{{ t("admin.groups.kiroCache.ratioHint") }}</p>
           </div>
+          <div v-if="createForm.kiro_cache_emulation_enabled" class="mt-3">
+            <label class="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                :checked="(createForm.kiro_cache_force_ratio_center || 0) > 0"
+                @change="(e) => createForm.kiro_cache_force_ratio_center = (e.target as HTMLInputElement).checked ? 0.925 : 0"
+              />
+              {{ t("admin.groups.kiroCache.forceRatio") }}
+            </label>
+            <p class="input-hint">{{ t("admin.groups.kiroCache.forceRatioHint") }}</p>
+          </div>
         </div>
 
         <div class="border-t pt-4">
@@ -2026,6 +2037,17 @@
               placeholder="1"
             />
             <p class="input-hint">{{ t("admin.groups.kiroCache.ratioHint") }}</p>
+          </div>
+          <div v-if="editForm.kiro_cache_emulation_enabled" class="mt-3">
+            <label class="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                :checked="(editForm.kiro_cache_force_ratio_center || 0) > 0"
+                @change="(e) => editForm.kiro_cache_force_ratio_center = (e.target as HTMLInputElement).checked ? 0.925 : 0"
+              />
+              {{ t("admin.groups.kiroCache.forceRatio") }}
+            </label>
+            <p class="input-hint">{{ t("admin.groups.kiroCache.forceRatioHint") }}</p>
           </div>
         </div>
 
@@ -3481,6 +3503,7 @@ const createForm = reactive({
   kiro_auto_sticky_enabled: true,
   kiro_sticky_session_ttl_seconds: 3600,
   kiro_cache_emulation_ratio: 1,
+  kiro_cache_force_ratio_center: 0 as number,
 });
 
 // 简单账号类型（用于模型路由选择）
@@ -3818,6 +3841,7 @@ const editForm = reactive({
   kiro_auto_sticky_enabled: true,
   kiro_sticky_session_ttl_seconds: 3600,
   kiro_cache_emulation_ratio: 1,
+  kiro_cache_force_ratio_center: 0 as number,
 });
 
 type ImagePricingFormState = {
@@ -4059,6 +4083,7 @@ const closeCreateModal = () => {
   createForm.kiro_auto_sticky_enabled = true;
   createForm.kiro_sticky_session_ttl_seconds = 3600;
   createForm.kiro_cache_emulation_ratio = 1;
+  createForm.kiro_cache_force_ratio_center = 0;
   resetModelsListState(createModelsListState);
   createModelRoutingRules.value = [];
 };
@@ -4153,6 +4178,7 @@ const handleCreateGroup = async () => {
       requestData.kiro_sticky_session_ttl_seconds = 0;
       requestData.kiro_cache_emulation_enabled = false;
       requestData.kiro_cache_emulation_ratio = 0;
+      requestData.kiro_cache_force_ratio_center = 0;
     } else {
       requestData.kiro_sticky_session_ttl_seconds = normalizeKiroStickySessionTTL(
         requestData.kiro_sticky_session_ttl_seconds,
@@ -4227,6 +4253,7 @@ const handleEdit = async (group: AdminGroup) => {
     group.kiro_sticky_session_ttl_seconds ?? 3600;
   editForm.kiro_cache_emulation_enabled = group.kiro_cache_emulation_enabled ?? false;
   editForm.kiro_cache_emulation_ratio = group.kiro_cache_emulation_ratio ?? 1;
+  editForm.kiro_cache_force_ratio_center = group.kiro_cache_force_ratio_center ?? 0;
   resetModelsListState(editModelsListState, group.models_list_config);
   // 加载模型路由规则（异步加载账号名称）
   editModelRoutingRules.value = await convertApiFormatToRoutingRules(
@@ -4308,6 +4335,7 @@ const handleUpdateGroup = async () => {
       payload.kiro_sticky_session_ttl_seconds = 0;
       payload.kiro_cache_emulation_enabled = false;
       payload.kiro_cache_emulation_ratio = 0;
+      payload.kiro_cache_force_ratio_center = 0;
     } else {
       payload.kiro_sticky_session_ttl_seconds = normalizeKiroStickySessionTTL(
         payload.kiro_sticky_session_ttl_seconds,


### PR DESCRIPTION
## 背景
上游已有的 Kiro 缓存模拟（`kiro_cache_emulation_enabled`）会在内置缓存识别返回 cache_read=0 时，模拟出一份 input/cache_read/cache_creation 拆分用于展示。但模拟出的分布与真实 Anthropic Claude Code 直连的形态有差距（真实形态是 input 极小、cache_read 占大头）。本 PR 增加一个开关，把模拟分布重塑成 Anthropic-like 形态，纯展示口径美化。

## 这次改了什么
- group 新增 `kiro_cache_force_ratio_center`（默认 0=禁用）。
- 当 `> 0` 且缓存模拟启用时，在 `buildKiroCacheEmulationUsage`（缓存模拟路径内部）把模拟出的拆分按一张分段拟合表重塑：input 钳到极小、剩余按 per-size 的 cache_read 比例切给 cache_read / cache_creation（cache_creation 归 5m TTL）。**总量守恒，纯展示，不改变真实计费总额。**
- 拟合表基于真实 Anthropic Claude Code 直连流量反推（≥20k 段 input p50≈2、cache_read 占比 0.82~0.93），随 total 分段插值。
- 该比例进 API key auth 快照（版本 bump 至 14）。
- group 创建/更新接口 + 管理后台开关（启用时写 0.925）暴露该字段。
- migration 153（新列默认 0）。

## 没有放进这次 PR 的内容
重塑只作用于「缓存模拟」路径（即上游真实 cache_read=0 时），不触碰真实上游返回的 usage；不参与计费金额（仅展示拆分）。

## 验证
```
go test -tags=unit ./internal/service -run 'KiroCacheForce|EffectiveKiroCacheForce|Kiro|Group|APIKeyAuth' -count=1
cd ../frontend && pnpm typecheck && pnpm lint:check
```
向后兼容：默认 0 保持现有行为；非 kiro 分组归一化清空该字段。

## 线上验证建议
给一个启用了缓存模拟的 Kiro 分组打开该开关，发请求后看 `usage_logs` 里该分组的 input 被压到极小、cache_read 占比贴近 0.9 左右，且 total（input+cache_read+cache_creation）与未开时一致（总量守恒）。
