### PR TITLE
feat(usage): 支持传递模型选项到使用清理对话框

### DIFF
--- a/frontend/src/components/admin/usage/UsageCleanupDialog.vue
+++ b/frontend/src/components/admin/usage/UsageCleanupDialog.vue
@@ -7,6 +7,7 @@
         v-model:endDate="localEndDate"
         :exporting="false"
         :show-actions="false"
+        :model-options="modelOptions"
         @change="noop"
       />
 
@@ -132,9 +133,12 @@ interface Props {
   filters: AdminUsageQueryParams
   startDate: string
   endDate: string
+  modelOptions?: string[]
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  modelOptions: () => []
+})
 const emit = defineEmits(['close'])
 
 const { t } = useI18n()

--- a/frontend/src/components/admin/usage/__tests__/UsageCleanupDialog.spec.ts
+++ b/frontend/src/components/admin/usage/__tests__/UsageCleanupDialog.spec.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+const { listCleanupTasks } = vi.hoisted(() => ({
+  listCleanupTasks: vi.fn(),
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showError: vi.fn(),
+    showSuccess: vi.fn(),
+  }),
+}))
+
+vi.mock('@/api/admin/usage', () => ({
+  default: {
+    listCleanupTasks,
+    createCleanupTask: vi.fn(),
+    cancelCleanupTask: vi.fn(),
+  },
+  adminUsageAPI: {
+    listCleanupTasks,
+    createCleanupTask: vi.fn(),
+    cancelCleanupTask: vi.fn(),
+  },
+}))
+
+vi.mock('@/api/admin', () => ({
+  adminAPI: {
+    usage: {
+      searchUsers: vi.fn().mockResolvedValue([]),
+      searchApiKeys: vi.fn().mockResolvedValue([]),
+    },
+    groups: {
+      list: vi.fn().mockResolvedValue({ items: [] }),
+    },
+    dashboard: {
+      getModelStats: vi.fn().mockResolvedValue({ models: [] }),
+    },
+    accounts: {
+      list: vi.fn().mockResolvedValue({ items: [] }),
+    },
+  },
+}))
+
+import UsageCleanupDialog from '../UsageCleanupDialog.vue'
+
+describe('UsageCleanupDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    listCleanupTasks.mockResolvedValue({ items: [], total: 0, page: 1, page_size: 5 })
+  })
+
+  it('把外部模型选项传给清理筛选器', async () => {
+    const wrapper = mount(UsageCleanupDialog, {
+      props: {
+        show: true,
+        filters: {},
+        startDate: '2026-07-01',
+        endDate: '2026-07-01',
+        modelOptions: ['claude-opus-4-8', 'gpt-5.4'],
+      },
+      global: {
+        stubs: {
+          BaseDialog: {
+            props: ['show'],
+            template: '<section v-if="show"><slot /><slot name="footer" /></section>',
+          },
+          ConfirmDialog: true,
+          Pagination: true,
+          UsageFilters: {
+            props: ['modelOptions'],
+            template: '<div data-test="model-options">{{ modelOptions.join(",") }}</div>',
+          },
+        },
+      },
+    })
+
+    await flushPromises()
+
+    expect(wrapper.get('[data-test="model-options"]').text()).toBe('claude-opus-4-8,gpt-5.4')
+  })
+})

--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -138,6 +138,7 @@
     :filters="filters"
     :start-date="startDate"
     :end-date="endDate"
+    :model-options="modelNameOptions"
     @close="cleanupDialogVisible = false"
   />
   <ConfirmDialog

--- a/frontend/src/views/admin/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/admin/__tests__/UsageView.spec.ts
@@ -188,6 +188,36 @@ describe('admin UsageView distribution metric toggles', () => {
     expect((wrapper.vm as any).requestedModelStats).toEqual([{ model: 'B', total_tokens: 20 }])
   })
 
+  it('passes requested model options to cleanup dialog', async () => {
+    getModelStats.mockResolvedValueOnce({
+      models: [
+        { model: 'claude-opus-4-8', total_tokens: 10 },
+        { model: 'gpt-5.4', total_tokens: 20 },
+      ],
+    })
+
+    const UsageCleanupDialogStub = {
+      props: ['modelOptions'],
+      template: '<div data-test="cleanup-model-options">{{ modelOptions.join(",") }}</div>',
+    }
+
+    const wrapper = mount(UsageView, {
+      global: { stubs: {
+        AppLayout: AppLayoutStub, UsageStatsCards: true, UsageFilters: UsageFiltersStub,
+        UsageTable: true, UsageExportProgress: true, UsageCleanupDialog: UsageCleanupDialogStub,
+        UserBalanceHistoryModal: true, AuditLogModal: true, Pagination: true, Select: true,
+        DateRangePicker: true, Icon: true, TokenUsageTrend: true,
+        ModelDistributionChart: ModelDistributionChartStub, GroupDistributionChart: GroupDistributionChartStub,
+        EndpointDistributionChart: true,
+      } },
+    })
+
+    vi.advanceTimersByTime(120)
+    await flushPromises()
+
+    expect(wrapper.get('[data-test="cleanup-model-options"]').text()).toBe('claude-opus-4-8,gpt-5.4')
+  })
+
   it('keeps model and group metric toggles independent without refetching chart data', async () => {
     const wrapper = mount(UsageView, {
       global: {


### PR DESCRIPTION
- 在UsageCleanupDialog组件中新增modelOptions属性，默认空数组
- 将modelOptions作为prop传递给UsageFilters子组件
- 在UsageView中传递modelNameOptions给UsageCleanupDialog
- 新增单元测试以验证modelOptions正确传递和渲染
- 保证清理对话框能接收并展示外部模型选项数据