### PR TITLE
refactor(ui): 将多个选择框替换为通用 Select 组件并添加确认对话框功能

### DIFF
--- a/frontend/src/components/admin/user/UserCreateModal.vue
+++ b/frontend/src/components/admin/user/UserCreateModal.vue
@@ -27,10 +27,7 @@
       </div>
       <div>
         <label class="input-label">{{ t('admin.users.form.roleLabel') }}</label>
-        <select v-model="form.role" class="input">
-          <option value="user">{{ t('admin.users.roles.user') }}</option>
-          <option value="admin">{{ t('admin.users.roles.admin') }}</option>
-        </select>
+        <Select v-model="form.role" :options="roleOptions" />
       </div>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div>
@@ -67,16 +64,22 @@
 </template>
 
 <script setup lang="ts">
-import { reactive, watch } from 'vue'
+import { reactive, watch, computed } from 'vue'
 import { useI18n } from 'vue-i18n'; import { adminAPI } from '@/api/admin'
 import { useForm } from '@/composables/useForm'
 import BaseDialog from '@/components/common/BaseDialog.vue'
+import Select, { type SelectOption } from '@/components/common/Select.vue'
 import Icon from '@/components/icons/Icon.vue'
 
 const props = defineProps<{ show: boolean }>()
 const emit = defineEmits(['close', 'success']); const { t } = useI18n()
 
 const form = reactive({ email: '', password: '', username: '', notes: '', role: 'user' as 'user' | 'admin', balance: '', concurrency: 1, rpm_limit: 0 })
+
+const roleOptions = computed<SelectOption[]>(() => [
+  { value: 'user', label: t('admin.users.roles.user') },
+  { value: 'admin', label: t('admin.users.roles.admin') },
+])
 
 const { loading, submit } = useForm({
   form,

--- a/frontend/src/components/admin/user/UserEditModal.vue
+++ b/frontend/src/components/admin/user/UserEditModal.vue
@@ -31,10 +31,7 @@
       </div>
       <div>
         <label class="input-label">{{ t('admin.users.form.roleLabel') }}</label>
-        <select v-model="form.role" class="input">
-          <option value="user">{{ t('admin.users.roles.user') }}</option>
-          <option value="admin">{{ t('admin.users.roles.admin') }}</option>
-        </select>
+        <Select v-model="form.role" :options="roleOptions" />
       </div>
       <div>
         <label class="input-label">{{ t('admin.users.notes') }}</label>
@@ -70,13 +67,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, watch } from 'vue'
+import { ref, reactive, watch, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
 import { useClipboard } from '@/composables/useClipboard'
 import { adminAPI } from '@/api/admin'
 import type { AdminUser, UserAttributeValuesMap } from '@/types'
 import BaseDialog from '@/components/common/BaseDialog.vue'
+import Select, { type SelectOption } from '@/components/common/Select.vue'
 import UserAttributeForm from '@/components/user/UserAttributeForm.vue'
 import Icon from '@/components/icons/Icon.vue'
 
@@ -86,6 +84,11 @@ const { t } = useI18n(); const appStore = useAppStore(); const { copyToClipboard
 
 const submitting = ref(false); const passwordCopied = ref(false)
 const form = reactive({ email: '', password: '', username: '', notes: '', role: 'user', concurrency: 1, rpm_limit: 0, customAttributes: {} as UserAttributeValuesMap })
+
+const roleOptions = computed<SelectOption[]>(() => [
+  { value: 'user', label: t('admin.users.roles.user') },
+  { value: 'admin', label: t('admin.users.roles.admin') },
+])
 
 watch(() => props.user, (u) => {
   if (u) {

--- a/frontend/src/views/user/BatchImageGuideView.vue
+++ b/frontend/src/views/user/BatchImageGuideView.vue
@@ -541,12 +541,13 @@
 
           <div class="md:col-span-2">
             <label class="input-label">API Key</label>
-            <select v-model.number="form.apiKeyId" class="input" :disabled="loadingKeys">
-              <option :value="0">{{ loadingKeys ? '加载 API Key 中...' : '请选择 Gemini API Key' }}</option>
-              <option v-for="key in geminiApiKeys" :key="key.id" :value="key.id">
-                {{ key.name }} · {{ key.group?.name || 'Gemini' }}
-              </option>
-            </select>
+            <Select
+              v-model="form.apiKeyId"
+              :options="apiKeyOptions"
+              :placeholder="apiKeyPlaceholder"
+              :disabled="loadingKeys"
+              class="w-full"
+            />
             <p v-if="!loadingKeys && geminiApiKeys.length === 0" class="input-hint text-amber-600 dark:text-amber-400">
               当前没有可用于批量生图的 Gemini API Key。请先创建并绑定已开启批量生图的 Gemini 分组。
             </p>
@@ -554,13 +555,13 @@
 
           <div>
             <label class="input-label">模型</label>
-            <select v-model="form.model" class="input" :disabled="loadingModels || availableBatchImageModels.length === 0">
-              <option v-if="loadingModels" value="">{{ batchImageText('loadingModels') }}</option>
-              <option v-else-if="availableBatchImageModels.length === 0" value="">{{ batchImageText('noModels') }}</option>
-              <option v-for="model in availableBatchImageModels" :key="model.value" :value="model.value">
-                {{ model.label }}
-              </option>
-            </select>
+            <Select
+              v-model="form.model"
+              :options="availableBatchImageModels"
+              :placeholder="modelPlaceholder"
+              :disabled="loadingModels || availableBatchImageModels.length === 0"
+              class="w-full"
+            />
             <p v-if="modelLoadError" class="input-hint text-amber-600 dark:text-amber-400">
               {{ modelLoadError }}
             </p>
@@ -579,11 +580,11 @@
 
           <div>
             <label class="input-label">输出格式</label>
-            <select v-model="form.responseMimeType" class="input">
-              <option value="image/png">PNG</option>
-              <option value="image/jpeg">JPEG</option>
-              <option value="image/webp">WebP</option>
-            </select>
+            <Select
+              v-model="form.responseMimeType"
+              :options="responseMimeTypeOptions"
+              class="w-full"
+            />
           </div>
 
           <div>
@@ -736,6 +737,15 @@
         </div>
       </template>
     </BaseDialog>
+
+    <ConfirmDialog
+      :show="confirmState.show"
+      :title="confirmState.title"
+      :message="confirmState.message"
+      :danger="confirmState.danger"
+      @confirm="handleConfirmAccept"
+      @cancel="handleConfirmCancel"
+    />
   </AppLayout>
 </template>
 
@@ -746,6 +756,7 @@ import AppLayout from '@/components/layout/AppLayout.vue'
 import TablePageLayout from '@/components/layout/TablePageLayout.vue'
 import DataTable from '@/components/common/DataTable.vue'
 import BaseDialog from '@/components/common/BaseDialog.vue'
+import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
 import Select, { type SelectOption } from '@/components/common/Select.vue'
 import SearchInput from '@/components/common/SearchInput.vue'
 import Icon from '@/components/icons/Icon.vue'
@@ -917,6 +928,38 @@ const promptPopover = reactive({
   text: '',
   style: {} as Record<string, string>,
 })
+const confirmState = reactive({
+  show: false,
+  title: '',
+  message: '',
+  danger: false,
+})
+let confirmResolve: ((value: boolean) => void) | null = null
+
+function openConfirm(options: { title: string; message: string; danger?: boolean }): Promise<boolean> {
+  confirmState.title = options.title
+  confirmState.message = options.message
+  confirmState.danger = options.danger ?? false
+  confirmState.show = true
+  return new Promise<boolean>((resolve) => {
+    confirmResolve = resolve
+  })
+}
+
+function handleConfirmAccept() {
+  confirmState.show = false
+  const resolve = confirmResolve
+  confirmResolve = null
+  resolve?.(true)
+}
+
+function handleConfirmCancel() {
+  confirmState.show = false
+  const resolve = confirmResolve
+  confirmResolve = null
+  resolve?.(false)
+}
+
 let modelRequestSeq = 0
 let pollTimer: ReturnType<typeof setInterval> | null = null
 let previewCacheDBPromise: Promise<IDBDatabase | null> | null = null
@@ -936,6 +979,29 @@ const geminiApiKeys = computed(() =>
 const selectedApiKey = computed(() =>
   geminiApiKeys.value.find((key) => key.id === Number(form.apiKeyId)) || null,
 )
+
+const apiKeyOptions = computed<SelectOption[]>(() =>
+  geminiApiKeys.value.map((key) => ({
+    value: key.id,
+    label: `${key.name} · ${key.group?.name || 'Gemini'}`,
+  })),
+)
+
+const apiKeyPlaceholder = computed(() =>
+  loadingKeys.value ? '加载 API Key 中...' : '请选择 Gemini API Key',
+)
+
+const modelPlaceholder = computed(() => {
+  if (loadingModels.value) return batchImageText('loadingModels')
+  if (availableBatchImageModels.value.length === 0) return batchImageText('noModels')
+  return batchImageText('selectModel')
+})
+
+const responseMimeTypeOptions: SelectOption[] = [
+  { value: 'image/png', label: 'PNG' },
+  { value: 'image/jpeg', label: 'JPEG' },
+  { value: 'image/webp', label: 'WebP' },
+]
 
 const filteredApiKeys = computed(() => {
   const selectedFilterID = Number(filters.apiKeyId || 0)
@@ -1759,7 +1825,7 @@ async function cancelSelected() {
   if (!currentJob.value) return
   const key = keyForSelectedBatch() || requireApiKey()
   if (!key) return
-  if (!window.confirm(batchImageText('cancelConfirm'))) return
+  if (!(await openConfirm({ title: batchImageText('cancelTitle'), message: batchImageText('cancelConfirm') }))) return
   cancelling.value = true
   try {
     const job = await cancelBatchImageJob(key.key, currentJob.value.id)
@@ -1895,7 +1961,7 @@ async function deleteJob(job: BatchImageJobRow) {
   closeMoreMenu()
   const key = apiKeyForJob(job)
   if (!key) return
-  if (!window.confirm(batchImageText('deleteConfirm'))) return
+  if (!(await openConfirm({ title: batchImageText('deleteTitle'), message: batchImageText('deleteConfirm'), danger: true }))) return
   deletingBatchId.value = job.id
   try {
     await deleteBatchImageJobRecord(key.key, job.id)
@@ -1911,7 +1977,7 @@ async function deleteJob(job: BatchImageJobRow) {
 async function deleteSelectedJobs() {
   const rows = selectedRows.value.filter(job => canDeleteRecord(job))
   if (bulkDeleting.value || rows.length === 0) return
-  if (!window.confirm(batchImageText('deleteSelectedConfirm'))) return
+  if (!(await openConfirm({ title: batchImageText('deleteTitle'), message: batchImageText('deleteSelectedConfirm'), danger: true }))) return
   bulkDeleting.value = true
   try {
     for (const row of rows) {
@@ -2444,6 +2510,8 @@ type BatchImageTextKey =
   | 'authRequired'
   | 'adminReference'
   | 'errorReference'
+  | 'cancelTitle'
+  | 'deleteTitle'
 
 function isZhLocale() {
   return String(locale.value || '').toLowerCase().startsWith('zh')
@@ -2509,6 +2577,8 @@ function batchImageText(key: BatchImageTextKey) {
     authRequired: '当前 API Key 不可用或已失效，请重新选择密钥。',
     adminReference: '请把错误码和请求 ID 发给管理员排查。',
     errorReference: '错误信息',
+    cancelTitle: '取消任务',
+    deleteTitle: '删除记录',
   }
   const en: Record<BatchImageTextKey, string> = {
     loadKeysFailed: 'Failed to load API keys.',
@@ -2569,6 +2639,8 @@ function batchImageText(key: BatchImageTextKey) {
     authRequired: 'The current API key is unavailable or expired. Select the key again.',
     adminReference: 'Send the error code and request ID to an administrator for troubleshooting.',
     errorReference: 'Error detail',
+    cancelTitle: 'Cancel job',
+    deleteTitle: 'Delete record',
   }
   return (isZhLocale() ? zh : en)[key]
 }


### PR DESCRIPTION
- 在 UserCreateModal 和 UserEditModal 中替换角色选择的原生 select 为 Select 组件
- 使用 computed 计算 roleOptions 来动态生成角色选项
- 在 BatchImageGuideView 中将 API Key、模型和输出格式的选择框替换为 Select 组件
- 为批量生图任务的取消和删除操作添加自定义确认对话框，替代 window.confirm
- 新增 ConfirmDialog 组件及其状态管理和响应函数
- 定义用于 Select 组件的多项 options 和占位文本的 computed 属性
- 补充国际化文本 key 如 cancel