### PR TITLE
fix(kiro): 修复工具流式输入处理和JSON输入解析问题

### DIFF
--- a/backend/internal/pkg/kiro/translator.go
+++ b/backend/internal/pkg/kiro/translator.go
@@ -59,7 +59,6 @@ const (
 )
 
 var (
-	trailingCommaPattern      = regexp.MustCompile(`,\s*([}\]])`)
 	kiroRemoteImageHTTPClient = &http.Client{Timeout: kiroRemoteImageTimeout}
 	requiredToolFields        = map[string][][]string{
 		"write":              {{"file_path", "path"}, {"content"}},
@@ -524,10 +523,12 @@ func StreamEventStreamAsAnthropicWithContext(ctx context.Context, body io.Reader
 	thinkingBlockOpen := false
 	processedIDs := make(map[string]bool)
 	emittedToolContents := make(map[string]bool)
-	streamingToolBlockIndices := make(map[string]int)
-	streamingToolStarted := make(map[string]bool)
+	streamingToolNames := make(map[string]string)
 	streamingToolStopped := make(map[string]bool)
+	streamingToolInputBuf := make(map[string]*strings.Builder)
+	streamingToolInvalid := make(map[string]bool)
 	currentStreamingToolID := ""
+	toolBlockEmitted := false
 	pendingAssistantText := ""
 	lastContentFragment := ""
 	pendingLeadingWhitespace := ""
@@ -615,37 +616,45 @@ func StreamEventStreamAsAnthropicWithContext(ctx context.Context, body io.Reader
 		thinkingBlockOpen = false
 		return writeEvent("content_block_stop", map[string]any{"type": "content_block_stop", "index": thinkingBlockIndex})
 	}
-	closeStreamingTool := func(toolUseID string) error {
-		if toolUseID == "" || !streamingToolStarted[toolUseID] || streamingToolStopped[toolUseID] {
-			return nil
+	discardStreamingTool := func(toolUseID string) {
+		if toolUseID == "" {
+			return
 		}
 		streamingToolStopped[toolUseID] = true
 		if currentStreamingToolID == toolUseID {
 			currentStreamingToolID = ""
 		}
-		return writeEvent("content_block_stop", map[string]any{"type": "content_block_stop", "index": streamingToolBlockIndices[toolUseID]})
+		delete(streamingToolNames, toolUseID)
+		delete(streamingToolInputBuf, toolUseID)
+		delete(streamingToolInvalid, toolUseID)
 	}
-	closeOpenStreamingTool := func() error {
-		return closeStreamingTool(currentStreamingToolID)
-	}
-	startStreamingToolUse := func(toolUseID, name string) error {
-		if toolUseID == "" || name == "" || streamingToolStopped[toolUseID] {
+	closeStreamingTool := func(toolUseID string) error {
+		if toolUseID == "" || streamingToolStopped[toolUseID] {
 			return nil
 		}
-		if currentStreamingToolID != "" && currentStreamingToolID != toolUseID {
-			if err := closeOpenStreamingTool(); err != nil {
-				return err
-			}
+		streamingToolStopped[toolUseID] = true
+
+		name := streamingToolNames[toolUseID]
+		buf := streamingToolInputBuf[toolUseID]
+		invalid := streamingToolInvalid[toolUseID]
+		discardStreamingTool(toolUseID)
+		if invalid || name == "" || buf == nil {
+			return nil
 		}
-		if stopReason == "" {
-			stopReason = "tool_use"
+
+		responseName := normalizeResponseToolName(restoreResponseToolName(name, requestCtx))
+		inputJSON, input, ok := normalizeStreamingToolInput(responseName, buf.String())
+		if !ok {
+			return nil
+		}
+		processedIDs[toolUseID] = true
+		tool := KiroToolUse{ToolUseID: toolUseID, Name: responseName, Input: input}
+		contentKey := toolUseContentKey(tool)
+		if contentKey == "" || emittedToolContents[contentKey] {
+			return nil
 		}
 		if err := ensureMessageStart(); err != nil {
 			return err
-		}
-		if firstDelta == nil {
-			delta := time.Since(start)
-			firstDelta = &delta
 		}
 		if err := closeThinking(); err != nil {
 			return err
@@ -653,74 +662,100 @@ func StreamEventStreamAsAnthropicWithContext(ctx context.Context, body io.Reader
 		if err := closeText(); err != nil {
 			return err
 		}
-		blockIndex, ok := streamingToolBlockIndices[toolUseID]
-		if !ok {
-			contentBlockIndex++
-			blockIndex = contentBlockIndex
-			streamingToolBlockIndices[toolUseID] = blockIndex
+		if firstDelta == nil {
+			delta := time.Since(start)
+			firstDelta = &delta
 		}
-		currentStreamingToolID = toolUseID
-		if streamingToolStarted[toolUseID] {
-			return nil
-		}
-		streamingToolStarted[toolUseID] = true
-		return writeEvent("content_block_start", map[string]any{
+		contentBlockIndex++
+		blockIndex := contentBlockIndex
+		if err := writeEvent("content_block_start", map[string]any{
 			"type":  "content_block_start",
 			"index": blockIndex,
 			"content_block": map[string]any{
 				"type":  "tool_use",
 				"id":    toolUseID,
-				"name":  restoreResponseToolName(name, requestCtx),
+				"name":  responseName,
 				"input": map[string]any{},
 			},
-		})
-	}
-	emitStreamingToolInput := func(toolUseID, name, fragment string) error {
-		if fragment == "" {
-			return nil
-		}
-		if err := startStreamingToolUse(toolUseID, name); err != nil {
+		}); err != nil {
 			return err
 		}
-		if toolUseID == "" || !streamingToolStarted[toolUseID] || streamingToolStopped[toolUseID] {
-			return nil
-		}
-		_, _ = outputTextBuf.WriteString(fragment)
-		return writeEvent("content_block_delta", map[string]any{
+		if err := writeEvent("content_block_delta", map[string]any{
 			"type":  "content_block_delta",
-			"index": streamingToolBlockIndices[toolUseID],
+			"index": blockIndex,
 			"delta": map[string]any{
 				"type":         "input_json_delta",
-				"partial_json": fragment,
+				"partial_json": inputJSON,
 			},
-		})
+		}); err != nil {
+			return err
+		}
+		if err := writeEvent("content_block_stop", map[string]any{"type": "content_block_stop", "index": blockIndex}); err != nil {
+			return err
+		}
+		emittedToolContents[contentKey] = true
+		toolBlockEmitted = true
+		_, _ = outputTextBuf.WriteString(inputJSON)
+		if stopReason == "" {
+			stopReason = "tool_use"
+		}
+		return nil
+	}
+	closeOpenStreamingTool := func() error {
+		return closeStreamingTool(currentStreamingToolID)
+	}
+	bufferStreamingToolInput := func(toolUseID, name, fragment string, snapshot bool) error {
+		if toolUseID == "" || processedIDs[toolUseID] || streamingToolStopped[toolUseID] {
+			return nil
+		}
+		if currentStreamingToolID != "" && currentStreamingToolID != toolUseID {
+			if err := closeOpenStreamingTool(); err != nil {
+				return err
+			}
+		}
+		currentStreamingToolID = toolUseID
+		if name != "" {
+			streamingToolNames[toolUseID] = name
+		}
+		if snapshot {
+			delete(streamingToolInvalid, toolUseID)
+		} else if streamingToolInvalid[toolUseID] {
+			return nil
+		}
+		buf, ok := streamingToolInputBuf[toolUseID]
+		if !ok {
+			buf = &strings.Builder{}
+			streamingToolInputBuf[toolUseID] = buf
+		}
+		if snapshot {
+			buf.Reset()
+		}
+		if len(fragment) > maxEventMsgSize-buf.Len() {
+			streamingToolInvalid[toolUseID] = true
+			delete(streamingToolInputBuf, toolUseID)
+			return nil
+		}
+		_, _ = buf.WriteString(fragment)
+		return nil
 	}
 	processStreamingToolInput := func(toolUseID, name, fragment string, inputMap map[string]any) error {
 		if toolUseID == "" {
 			return nil
 		}
-		if err := startStreamingToolUse(toolUseID, name); err != nil {
-			return err
-		}
+		snapshot := false
 		if inputMap != nil {
 			encoded, err := json.Marshal(inputMap)
 			if err != nil {
 				return err
 			}
 			fragment = string(encoded)
+			snapshot = true
 		}
-		return emitStreamingToolInput(toolUseID, name, fragment)
+		return bufferStreamingToolInput(toolUseID, name, fragment, snapshot)
 	}
 	processStreamingToolStop := func(toolUseID string) error {
 		if toolUseID == "" {
 			toolUseID = currentStreamingToolID
-		}
-		if toolUseID == "" {
-			return nil
-		}
-		processedIDs[toolUseID] = true
-		if stopReason == "" {
-			stopReason = "tool_use"
 		}
 		return closeStreamingTool(toolUseID)
 	}
@@ -810,10 +845,15 @@ func StreamEventStreamAsAnthropicWithContext(ctx context.Context, body io.Reader
 		return writeTextDelta(text, true)
 	}
 	emitToolUse := func(tool KiroToolUse) error {
+		structuredOutput := isStructuredOutputToolName(tool.Name, requestCtx)
+		tool.Name = normalizeResponseToolName(restoreResponseToolName(tool.Name, requestCtx))
+		if !structuredOutput && !isEmittableToolUse(tool) {
+			return nil
+		}
 		if !shouldEmitToolUse(tool, emittedToolContents) {
 			return nil
 		}
-		if isStructuredOutputToolName(tool.Name, requestCtx) {
+		if structuredOutput {
 			inputJSON, err := json.Marshal(tool.Input)
 			if err != nil {
 				inputJSON = []byte("{}")
@@ -842,7 +882,7 @@ func StreamEventStreamAsAnthropicWithContext(ctx context.Context, body io.Reader
 			"content_block": map[string]any{
 				"type":  "tool_use",
 				"id":    tool.ToolUseID,
-				"name":  restoreResponseToolName(tool.Name, requestCtx),
+				"name":  tool.Name,
 				"input": map[string]any{},
 			},
 		}); err != nil {
@@ -860,7 +900,11 @@ func StreamEventStreamAsAnthropicWithContext(ctx context.Context, body io.Reader
 		}); err != nil {
 			return err
 		}
-		return writeEvent("content_block_stop", map[string]any{"type": "content_block_stop", "index": contentBlockIndex})
+		if err := writeEvent("content_block_stop", map[string]any{"type": "content_block_stop", "index": contentBlockIndex}); err != nil {
+			return err
+		}
+		toolBlockEmitted = true
+		return nil
 	}
 	flushPendingAssistantText := func() error {
 		text, embeddedTools, pending := drainEmbeddedToolText(pendingAssistantText)
@@ -1048,9 +1092,16 @@ func StreamEventStreamAsAnthropicWithContext(ctx context.Context, body io.Reader
 		// 上游中间帧若透传 pause_turn/refusal/stop_sequence 等新值会让客户端误判为终态
 		// 其余值忽略,等流真正 EOF 时由后续兜底分支按 tool_use/end_turn 处理
 		if evt.SourceStopReason != "" {
-			switch strings.ToLower(strings.TrimSpace(evt.SourceStopReason)) {
-			case "end_turn", "tool_use", "max_tokens":
-				stopReason = evt.SourceStopReason
+			sourceStopReason := strings.ToLower(strings.TrimSpace(evt.SourceStopReason))
+			switch sourceStopReason {
+			case "max_tokens":
+				if stopReason != "stop_sequence" {
+					stopReason = sourceStopReason
+				}
+			case "end_turn", "tool_use":
+				if stopReason != "max_tokens" && stopReason != "stop_sequence" {
+					stopReason = sourceStopReason
+				}
 			}
 		}
 		switch evt.Type {
@@ -1079,6 +1130,11 @@ func StreamEventStreamAsAnthropicWithContext(ctx context.Context, body io.Reader
 			if evt.ToolUse == nil || processedIDs[evt.ToolUse.ToolUseID] {
 				return nil
 			}
+			structuredOutput := isStructuredOutputToolName(evt.ToolUse.Name, requestCtx)
+			if (!structuredOutput && !isEmittableToolUse(*evt.ToolUse)) || evt.ToolUse.IsTruncated {
+				return nil
+			}
+			discardStreamingTool(evt.ToolUse.ToolUseID)
 			processedIDs[evt.ToolUse.ToolUseID] = true
 			if err := flushThinkingAtBoundary(); err != nil {
 				return err
@@ -1126,7 +1182,13 @@ func StreamEventStreamAsAnthropicWithContext(ctx context.Context, body io.Reader
 		}
 
 		var event map[string]any
-		if err := json.Unmarshal(msg.Payload, &event); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(msg.Payload))
+		decoder.UseNumber()
+		if err := decoder.Decode(&event); err != nil {
+			continue
+		}
+		var trailing any
+		if err := decoder.Decode(&trailing); err != io.EOF {
 			continue
 		}
 
@@ -1172,10 +1234,19 @@ func StreamEventStreamAsAnthropicWithContext(ctx context.Context, body io.Reader
 	if requestCtx.CacheEmulationUsage != nil {
 		usage = mergeKiroCacheEmulationUsage(usage, requestCtx.CacheEmulationUsage)
 	}
-	if stopReason == "" {
-		if len(emittedToolContents) > 0 {
+	switch stopReason {
+	case "max_tokens", "stop_sequence":
+		// These terminal conditions take precedence over emitted tool blocks.
+	case "":
+		if toolBlockEmitted {
 			stopReason = "tool_use"
 		} else {
+			stopReason = "end_turn"
+		}
+	default:
+		if toolBlockEmitted {
+			stopReason = "tool_use"
+		} else if stopReason == "tool_use" {
 			stopReason = "end_turn"
 		}
 	}
@@ -2838,7 +2909,13 @@ func parseEventStream(body io.Reader) (string, []KiroToolUse, Usage, string, err
 		}
 
 		var event map[string]any
-		if err := json.Unmarshal(msg.Payload, &event); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(msg.Payload))
+		decoder.UseNumber()
+		if err := decoder.Decode(&event); err != nil {
+			continue
+		}
+		var trailing any
+		if err := decoder.Decode(&trailing); err != io.EOF {
 			continue
 		}
 		if sr := readStopReason(event); sr != "" {
@@ -2962,7 +3039,7 @@ func buildClaudeResponse(content string, toolUses []KiroToolUse, model string, u
 	}
 	usableTools := 0
 	for _, tool := range toolUses {
-		if tool.IsTruncated {
+		if !isEmittableToolUse(tool) {
 			continue
 		}
 		usableTools++
@@ -3597,9 +3674,11 @@ func extractSemanticEvents(eventType string, event map[string]any, lastContentFr
 		toolUseID := getString(tu, "toolUseId")
 		name := getString(tu, "name")
 		isStop, _ := tu["stop"].(bool)
+		inputSeen := false
 		if inputRaw, ok := tu["input"]; ok {
 			switch v := inputRaw.(type) {
 			case string:
+				inputSeen = true
 				if toolUseID != "" && name != "" {
 					out = append(out, kiroSemanticEvent{
 						Type:             kiroSemanticToolUse,
@@ -3619,6 +3698,7 @@ func extractSemanticEvents(eventType string, event map[string]any, lastContentFr
 					})
 				}
 			case map[string]any:
+				inputSeen = true
 				if toolUseID != "" && name != "" {
 					out = append(out, kiroSemanticEvent{
 						Type:             kiroSemanticToolUse,
@@ -3638,6 +3718,14 @@ func extractSemanticEvents(eventType string, event map[string]any, lastContentFr
 					})
 				}
 			}
+		}
+		if !inputSeen && toolUseID != "" && name != "" {
+			out = append(out, kiroSemanticEvent{
+				Type:             kiroSemanticToolUse,
+				ToolUseID:        toolUseID,
+				ToolName:         name,
+				SourceStopReason: sourceStopReason,
+			})
 		}
 		if isStop {
 			out = append(out, kiroSemanticEvent{
@@ -3667,6 +3755,33 @@ func extractSemanticEvents(eventType string, event map[string]any, lastContentFr
 	return out
 }
 
+func normalizeStreamingToolInput(name, raw string) (string, map[string]any, bool) {
+	normalized := strings.TrimSpace(raw)
+	if normalized == "" {
+		return "", nil, false
+	}
+	normalized = escapeControlCharsInStrings(normalized)
+	normalized = removeTrailingCommasOutsideStrings(normalized)
+	decoder := json.NewDecoder(strings.NewReader(normalized))
+	decoder.UseNumber()
+	var input map[string]any
+	if err := decoder.Decode(&input); err != nil || input == nil {
+		return "", nil, false
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return "", nil, false
+	}
+	if hasMissingRequiredFields(name, input) {
+		return "", nil, false
+	}
+	encoded, err := json.Marshal(input)
+	if err != nil {
+		return "", nil, false
+	}
+	return string(encoded), input, true
+}
+
 func repairJSON(input string) string {
 	str := strings.TrimSpace(input)
 	if str == "" {
@@ -3677,7 +3792,7 @@ func repairJSON(input string) string {
 		return str
 	}
 	str = escapeControlCharsInStrings(str)
-	str = trailingCommaPattern.ReplaceAllString(str, "$1")
+	str = removeTrailingCommasOutsideStrings(str)
 	openBraces, openBrackets, inString := jsonBalance(str)
 	if inString {
 		str += `"`
@@ -3697,12 +3812,32 @@ func repairJSON(input string) string {
 
 func escapeControlCharsInStrings(input string) string {
 	var out strings.Builder
+	writeEscapedControl := func(ch byte) {
+		switch ch {
+		case '\n':
+			_, _ = out.WriteString("\\n")
+		case '\r':
+			_, _ = out.WriteString("\\r")
+		case '\t':
+			_, _ = out.WriteString("\\t")
+		default:
+			const hex = "0123456789abcdef"
+			_, _ = out.WriteString("\\u00")
+			_ = out.WriteByte(hex[ch>>4])
+			_ = out.WriteByte(hex[ch&0x0f])
+		}
+	}
 	inString := false
 	escape := false
 	for i := 0; i < len(input); i++ {
 		ch := input[i]
 		if escape {
-			_ = out.WriteByte(ch)
+			if inString && ch < 0x20 {
+				_ = out.WriteByte('\\')
+				writeEscapedControl(ch)
+			} else {
+				_ = out.WriteByte(ch)
+			}
 			escape = false
 			continue
 		}
@@ -3716,16 +3851,52 @@ func escapeControlCharsInStrings(input string) string {
 			_ = out.WriteByte(ch)
 			continue
 		}
+		if inString && ch < 0x20 {
+			writeEscapedControl(ch)
+			continue
+		}
+		_ = out.WriteByte(ch)
+	}
+	return out.String()
+}
+
+func removeTrailingCommasOutsideStrings(input string) string {
+	var out strings.Builder
+	out.Grow(len(input))
+	inString := false
+	escape := false
+	for i := 0; i < len(input); i++ {
+		ch := input[i]
 		if inString {
+			_ = out.WriteByte(ch)
+			if escape {
+				escape = false
+				continue
+			}
 			switch ch {
-			case '\n':
-				_, _ = out.WriteString("\\n")
-				continue
-			case '\r':
-				_, _ = out.WriteString("\\r")
-				continue
-			case '\t':
-				_, _ = out.WriteString("\\t")
+			case '\\':
+				escape = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		if ch == '"' {
+			inString = true
+			_ = out.WriteByte(ch)
+			continue
+		}
+		if ch == ',' {
+			next := i + 1
+			for next < len(input) {
+				switch input[next] {
+				case ' ', '\t', '\n', '\r':
+					next++
+					continue
+				}
+				break
+			}
+			if next < len(input) && (input[next] == '}' || input[next] == ']') {
 				continue
 			}
 		}
@@ -3775,11 +3946,21 @@ func finalizeRawToolUse(toolUseID, name, rawInput string) KiroToolUse {
 	}
 	rawInput = strings.TrimSpace(rawInput)
 	tool.TruncatedRaw = rawInput
+	decoded := false
 	repaired := repairJSON(rawInput)
 	if strings.TrimSpace(repaired) != "" {
-		_ = json.Unmarshal([]byte(repaired), &tool.Input)
+		decoder := json.NewDecoder(strings.NewReader(repaired))
+		decoder.UseNumber()
+		var input map[string]any
+		if err := decoder.Decode(&input); err == nil && input != nil {
+			var trailing any
+			if err := decoder.Decode(&trailing); err == io.EOF {
+				tool.Input = input
+				decoded = true
+			}
+		}
 	}
-	tool.IsTruncated = isTruncatedToolUse(tool.Name, rawInput, tool.Input)
+	tool.IsTruncated = !decoded || isTruncatedToolUse(tool.Name, rawInput, tool.Input)
 	return tool
 }
 
@@ -3804,6 +3985,10 @@ func normalizeResponseToolName(name string) string {
 	return name
 }
 
+func isEmittableToolUse(tool KiroToolUse) bool {
+	return !tool.IsTruncated && strings.TrimSpace(tool.ToolUseID) != "" && strings.TrimSpace(tool.Name) != ""
+}
+
 func shouldEmitToolUse(tool KiroToolUse, emittedToolContents map[string]bool) bool {
 	if tool.IsTruncated {
 		return false
@@ -3821,7 +4006,7 @@ func shouldEmitToolUse(tool KiroToolUse, emittedToolContents map[string]bool) bo
 
 func hasUsableToolUses(toolUses []KiroToolUse) bool {
 	for _, tool := range toolUses {
-		if !tool.IsTruncated {
+		if isEmittableToolUse(tool) {
 			return true
 		}
 	}

--- a/backend/internal/pkg/kiro/translator_test.go
+++ b/backend/internal/pkg/kiro/translator_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -571,6 +572,42 @@ func TestParseNonStreamingEventStream(t *testing.T) {
 	require.True(t, strings.Contains(firstText, "hello from kiro"))
 }
 
+func TestParseNonStreamingEventStreamPreservesLargeIntegerInMapInput(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_non_stream_map_large_integer",
+			"name":      "custom_tool",
+			"input": map[string]any{
+				"id": json.Number("9007199254740993"),
+			},
+			"stop": true,
+		},
+	}))
+
+	result, err := ParseNonStreamingEventStreamWithContext(stream, "claude-sonnet-4-5", KiroRequestContext{})
+	require.NoError(t, err)
+	require.Equal(t, "tool_use", result.StopReason)
+	require.Equal(t, "9007199254740993", gjson.GetBytes(result.ResponseBody, "content.0.input.id").Raw)
+}
+
+func TestParseNonStreamingEventStreamRejectsTrailingJSONValueInToolInput(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_non_stream_trailing_input",
+			"name":      "custom_tool",
+			"input":     `{"value":"valid first object"} {}`,
+			"stop":      true,
+		},
+	}))
+
+	result, err := ParseNonStreamingEventStreamWithContext(stream, "claude-sonnet-4-5", KiroRequestContext{})
+	require.NoError(t, err)
+	require.Equal(t, "end_turn", result.StopReason)
+	require.NotContains(t, string(result.ResponseBody), `"id":"toolu_non_stream_trailing_input"`)
+}
+
 func TestParseNonStreamingEventStreamCapturesKiroCredits(t *testing.T) {
 	stream := bytes.NewBuffer(nil)
 	_, _ = stream.Write(buildEventStreamFrame(t, "assistantResponseEvent", map[string]any{
@@ -1065,12 +1102,92 @@ func TestStreamEventStreamAsAnthropicStreamsToolUseFragments(t *testing.T) {
 
 	output := out.String()
 	require.Equal(t, 1, strings.Count(output, `"id":"toolu_stream"`))
-	require.Contains(t, output, `"partial_json":"{\"path\":\"/tmp/a.txt\","`)
-	require.Contains(t, output, `"partial_json":"\"content\":\"hello\"}"`)
+	require.Equal(t, 1, strings.Count(output, `"type":"input_json_delta"`))
+	partial := extractStreamedToolInputJSON(t, output, "toolu_stream")
+	var input map[string]any
+	require.NoError(t, json.Unmarshal([]byte(partial), &input))
+	require.Equal(t, map[string]any{"path": "/tmp/a.txt", "content": "hello"}, input)
 	require.Contains(t, output, `event: content_block_stop`)
 }
 
-func TestStreamEventStreamAsAnthropicStreamsIncompleteToolUseFragment(t *testing.T) {
+func TestStreamEventStreamAsAnthropicUsesToolStopReasonWhenValidToolWasEmitted(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"stopReason": "end_turn",
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_valid_end_turn",
+			"name":      "write_file",
+			"input":     `{"path":"main.go","content":"package main"}`,
+			"stop":      true,
+		},
+	}))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+	require.NoError(t, err)
+	require.Equal(t, "tool_use", result.StopReason)
+	require.Contains(t, out.String(), `"id":"toolu_valid_end_turn"`)
+	require.Contains(t, out.String(), `"stop_reason":"tool_use"`)
+}
+
+func TestStreamEventStreamAsAnthropicPreservesMaxTokensWhenValidToolWasEmitted(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"stopReason": "max_tokens",
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_valid_max_tokens",
+			"name":      "write_file",
+			"input":     `{"path":"main.go","content":"package main"}`,
+			"stop":      true,
+		},
+	}))
+
+	_, _ = stream.Write(buildEventStreamFrame(t, "messageMetadataEvent", map[string]any{
+		"stopReason": "end_turn",
+	}))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+	require.NoError(t, err)
+	require.Equal(t, "max_tokens", result.StopReason)
+	require.Contains(t, out.String(), `"id":"toolu_valid_max_tokens"`)
+	require.Contains(t, out.String(), `"stop_reason":"max_tokens"`)
+}
+
+func TestStreamEventStreamAsAnthropicPreservesStopSequenceWhenValidToolWasEmitted(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "assistantResponseEvent", map[string]any{
+		"assistantResponseEvent": map[string]any{
+			"content": "before<STOP>after",
+		},
+	}))
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_valid_stop_sequence",
+			"name":      "custom_tool",
+			"input":     `{"ok":true}`,
+			"stop":      true,
+		},
+	}))
+
+	_, _ = stream.Write(buildEventStreamFrame(t, "messageMetadataEvent", map[string]any{
+		"stopReason": "end_turn",
+	}))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{
+		StopSequences: []string{"<STOP>"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "stop_sequence", result.StopReason)
+	require.Contains(t, out.String(), `"id":"toolu_valid_stop_sequence"`)
+	require.Contains(t, out.String(), `"stop_reason":"stop_sequence"`)
+	messageDelta := extractSSEEventData(t, out.String(), "message_delta")
+	require.Equal(t, "<STOP>", gjson.GetBytes(messageDelta, "delta.stop_sequence").String())
+	require.NotContains(t, out.String(), "after")
+}
+
+func TestStreamEventStreamAsAnthropicSkipsIncompleteToolUseFragment(t *testing.T) {
 	stream := bytes.NewBuffer(nil)
 	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
 		"toolUseEvent": map[string]any{
@@ -1084,8 +1201,53 @@ func TestStreamEventStreamAsAnthropicStreamsIncompleteToolUseFragment(t *testing
 	var out bytes.Buffer
 	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
 	require.NoError(t, err)
+	require.Equal(t, "end_turn", result.StopReason)
+	require.NotContains(t, out.String(), `"id":"toolu_incomplete"`)
+	require.NotContains(t, out.String(), `"type":"input_json_delta"`)
+}
+
+func TestStreamEventStreamAsAnthropicSkipsIncompleteToolUseDespiteUpstreamToolUseStopReason(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"stopReason": "tool_use",
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_incomplete_stop_reason",
+			"name":      "write_file",
+			"input":     `{"path":`,
+			"stop":      true,
+		},
+	}))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+	require.NoError(t, err)
+	require.Equal(t, "end_turn", result.StopReason)
+	require.NotContains(t, out.String(), `"id":"toolu_incomplete_stop_reason"`)
+}
+
+func TestStreamEventStreamAsAnthropicKeepsToolNameFromSeparateStartFrame(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_separate_name",
+			"name":      "write_file",
+		},
+	}))
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_separate_name",
+			"input":     `{"path":"main.go","content":"package main"}`,
+			"stop":      true,
+		},
+	}))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+	require.NoError(t, err)
 	require.Equal(t, "tool_use", result.StopReason)
-	require.Contains(t, out.String(), `"partial_json":"{\"path\":"`)
+	require.Contains(t, out.String(), `"id":"toolu_separate_name"`)
+	require.Contains(t, out.String(), `"name":"write_file"`)
+	require.Equal(t, `{"content":"package main","path":"main.go"}`, extractStreamedToolInputJSON(t, out.String(), "toolu_separate_name"))
 }
 
 func TestStreamEventStreamAsAnthropicStopsPreviousToolWhenIDChanges(t *testing.T) {
@@ -1213,6 +1375,232 @@ func TestStreamEventStreamAsAnthropicStreamsToolUseMapInput(t *testing.T) {
 	_, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
 	require.NoError(t, err)
 	require.Contains(t, out.String(), `"partial_json":"{\"query\":\"golang\"}"`)
+}
+
+func TestStreamEventStreamAsAnthropicSkipsPayloadWithTrailingJSONValue(t *testing.T) {
+	payload := []byte(`{"toolUseEvent":{"toolUseId":"toolu_trailing_payload","name":"custom_tool","input":{"ok":true},"stop":true}} {}`)
+	stream := bytes.NewBuffer(buildRawEventStreamFrame(t, "toolUseEvent", payload))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+	require.NoError(t, err)
+	require.Equal(t, "end_turn", result.StopReason)
+	require.NotContains(t, out.String(), `"id":"toolu_trailing_payload"`)
+}
+
+func TestStreamEventStreamAsAnthropicPreservesLargeIntegerInMapInput(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_map_large_integer",
+			"name":      "custom_tool",
+			"input": map[string]any{
+				"id": json.Number("9007199254740993"),
+			},
+			"stop": true,
+		},
+	}))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+	require.NoError(t, err)
+	require.Equal(t, "tool_use", result.StopReason)
+	partial := extractStreamedToolInputJSON(t, out.String(), "toolu_map_large_integer")
+	require.Equal(t, `{"id":9007199254740993}`, partial)
+}
+
+func TestStreamEventStreamAsAnthropicMapSnapshotReplacesFragments(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_snapshot",
+			"name":      "remote_web_search",
+			"input":     `{"query":"stale`,
+		},
+	}))
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_snapshot",
+			"name":      "remote_web_search",
+			"input":     map[string]any{"query": "golang"},
+			"stop":      true,
+		},
+	}))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+	require.NoError(t, err)
+	require.Equal(t, "tool_use", result.StopReason)
+	partial := extractStreamedToolInputJSON(t, out.String(), "toolu_snapshot")
+	require.JSONEq(t, `{"query":"golang"}`, partial)
+	require.NotContains(t, partial, "stale")
+}
+
+func TestStreamEventStreamAsAnthropicSkipsOversizedToolInput(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	fragmentSize := maxEventMsgSize/2 + 1024
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_oversized",
+			"name":      "ExitPlanMode",
+			"input":     `{"plan":"` + strings.Repeat("a", fragmentSize),
+		},
+	}))
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_oversized",
+			"name":      "ExitPlanMode",
+			"input":     strings.Repeat("b", fragmentSize) + `"}`,
+			"stop":      true,
+		},
+	}))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+	require.NoError(t, err)
+	require.Equal(t, "end_turn", result.StopReason)
+	require.Zero(t, result.Usage.OutputTokens)
+	require.NotContains(t, out.String(), `"id":"toolu_oversized"`)
+	require.NotContains(t, out.String(), `"type":"input_json_delta"`)
+}
+
+func TestStreamEventStreamAsAnthropicMapSnapshotRecoversOversizedFragments(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	fragmentSize := maxEventMsgSize/2 + 1024
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_oversized_snapshot_recovery",
+			"name":      "custom_tool",
+			"input":     `{"value":"` + strings.Repeat("a", fragmentSize),
+		},
+	}))
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_oversized_snapshot_recovery",
+			"name":      "custom_tool",
+			"input":     strings.Repeat("b", fragmentSize),
+		},
+	}))
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_oversized_snapshot_recovery",
+			"name":      "custom_tool",
+			"input":     map[string]any{"value": "snapshot"},
+			"stop":      true,
+		},
+	}))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+	require.NoError(t, err)
+	require.Equal(t, "tool_use", result.StopReason)
+	require.JSONEq(t, `{"value":"snapshot"}`, extractStreamedToolInputJSON(t, out.String(), "toolu_oversized_snapshot_recovery"))
+}
+
+func TestStreamEventStreamAsAnthropicRepairsControlCharsInToolInput(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	// 上游把带真实换行的大段参数逐帧透传(plan 模式 ExitPlanMode.plan 常见)。
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_plan",
+			"name":      "ExitPlanMode",
+			"input":     "{\"plan\":\"step 1\nstep 2\"}",
+		},
+	}))
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_plan",
+			"name":      "ExitPlanMode",
+			"stop":      true,
+		},
+	}))
+
+	var out bytes.Buffer
+	_, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+	require.NoError(t, err)
+
+	partial := extractStreamedToolInputJSON(t, out.String(), "toolu_plan")
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(partial), &decoded))
+	require.Equal(t, "step 1\nstep 2", decoded["plan"])
+}
+
+func TestStreamEventStreamAsAnthropicPreservesCommaClosersInsideToolInputString(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	plan := "run printf ',}' and ',]'\nthen verify"
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_plan_commas",
+			"name":      "ExitPlanMode",
+			"input":     "{\"plan\":\"" + plan + "\"}",
+			"stop":      true,
+		},
+	}))
+
+	var out bytes.Buffer
+	_, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+	require.NoError(t, err)
+
+	partial := extractStreamedToolInputJSON(t, out.String(), "toolu_plan_commas")
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(partial), &decoded))
+	require.Equal(t, plan, decoded["plan"])
+}
+
+func extractSSEEventData(t *testing.T, sse, eventType string) []byte {
+	t.Helper()
+	for _, block := range strings.Split(sse, "\n\n") {
+		lines := strings.Split(block, "\n")
+		if len(lines) == 0 || lines[0] != "event: "+eventType {
+			continue
+		}
+		for _, line := range lines[1:] {
+			if strings.HasPrefix(line, "data: ") {
+				return []byte(strings.TrimPrefix(line, "data: "))
+			}
+		}
+	}
+	require.FailNow(t, "SSE event not found", "event type: %s", eventType)
+	return nil
+}
+
+func extractStreamedToolInputJSON(t *testing.T, sse, toolUseID string) string {
+	t.Helper()
+	var sb strings.Builder
+	targetIndex := -1
+	for _, block := range strings.Split(sse, "\n\n") {
+		line := ""
+		for _, l := range strings.Split(block, "\n") {
+			if strings.HasPrefix(l, "data: ") {
+				line = strings.TrimPrefix(l, "data: ")
+			}
+		}
+		if line == "" {
+			continue
+		}
+		var evt map[string]any
+		if err := json.Unmarshal([]byte(line), &evt); err != nil {
+			continue
+		}
+		switch evt["type"] {
+		case "content_block_start":
+			if cb, _ := evt["content_block"].(map[string]any); cb != nil && cb["id"] == toolUseID {
+				if idx, ok := evt["index"].(float64); ok {
+					targetIndex = int(idx)
+				}
+			}
+		case "content_block_delta":
+			if idx, ok := evt["index"].(float64); ok && int(idx) == targetIndex {
+				if delta, _ := evt["delta"].(map[string]any); delta != nil {
+					if pj, ok := delta["partial_json"].(string); ok {
+						sb.WriteString(pj)
+					}
+				}
+			}
+		}
+	}
+	require.NotEqual(t, -1, targetIndex)
+	return sb.String()
 }
 
 func TestStreamEventStreamAsAnthropicIgnoresPingFrames(t *testing.T) {
@@ -1659,6 +2047,223 @@ func TestParseNonStreamingEventStreamRestoresShortToolName(t *testing.T) {
 	require.Equal(t, longName, gjson.GetBytes(result.ResponseBody, "content.0.name").String())
 }
 
+func TestAssistantToolSnapshotRequiresIDAndName(t *testing.T) {
+	tests := []struct {
+		name string
+		tool map[string]any
+	}{
+		{
+			name: "missing id",
+			tool: map[string]any{"name": "custom_tool", "input": map[string]any{"value": true}},
+		},
+		{
+			name: "missing name",
+			tool: map[string]any{"toolUseId": "toolu_missing_name", "input": map[string]any{"value": true}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+" non-streaming", func(t *testing.T) {
+			stream := bytes.NewBuffer(buildEventStreamFrame(t, "assistantResponseEvent", map[string]any{
+				"assistantResponseEvent": map[string]any{"toolUses": []map[string]any{tt.tool}},
+			}))
+
+			result, err := ParseNonStreamingEventStreamWithContext(stream, "claude-sonnet-4-5", KiroRequestContext{})
+			require.NoError(t, err)
+			require.Equal(t, "end_turn", result.StopReason)
+			require.NotContains(t, string(result.ResponseBody), `"type":"tool_use"`)
+		})
+
+		t.Run(tt.name+" streaming", func(t *testing.T) {
+			stream := bytes.NewBuffer(buildEventStreamFrame(t, "assistantResponseEvent", map[string]any{
+				"assistantResponseEvent": map[string]any{"toolUses": []map[string]any{tt.tool}},
+			}))
+
+			var out bytes.Buffer
+			result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+			require.NoError(t, err)
+			require.Equal(t, "end_turn", result.StopReason)
+			require.NotContains(t, out.String(), `"type":"tool_use"`)
+		})
+	}
+}
+
+func TestStreamEventStreamAsAnthropicInvalidAssistantSnapshotDoesNotDiscardBufferedSameID(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_invalid_snapshot_same_id",
+			"name":      "custom_tool",
+			"input":     `{"value":"stream"}`,
+		},
+	}))
+	_, _ = stream.Write(buildEventStreamFrame(t, "assistantResponseEvent", map[string]any{
+		"assistantResponseEvent": map[string]any{
+			"toolUses": []map[string]any{
+				{
+					"toolUseId": "toolu_invalid_snapshot_same_id",
+					"input":     map[string]any{"value": "invalid-snapshot"},
+				},
+			},
+		},
+	}))
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_invalid_snapshot_same_id",
+			"stop":      true,
+		},
+	}))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+	require.NoError(t, err)
+	require.Equal(t, "tool_use", result.StopReason)
+	require.Equal(t, 1, strings.Count(out.String(), `"id":"toolu_invalid_snapshot_same_id"`))
+	require.JSONEq(t, `{"value":"stream"}`, extractStreamedToolInputJSON(t, out.String(), "toolu_invalid_snapshot_same_id"))
+}
+
+func TestStreamEventStreamAsAnthropicIgnoresStreamingDuplicateAfterAssistantToolSnapshot(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "assistantResponseEvent", map[string]any{
+		"assistantResponseEvent": map[string]any{
+			"toolUses": []map[string]any{
+				{
+					"toolUseId": "toolu_same_id_snapshot_first",
+					"name":      "custom_tool",
+					"input":     map[string]any{"value": "snapshot"},
+				},
+			},
+		},
+	}))
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_same_id_snapshot_first",
+			"name":      "custom_tool",
+			"input":     map[string]any{"value": "stale-stream"},
+			"stop":      true,
+		},
+	}))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+	require.NoError(t, err)
+	require.Equal(t, "tool_use", result.StopReason)
+	require.Equal(t, 1, strings.Count(out.String(), `"id":"toolu_same_id_snapshot_first"`))
+	require.JSONEq(t, `{"value":"snapshot"}`, extractStreamedToolInputJSON(t, out.String(), "toolu_same_id_snapshot_first"))
+}
+
+func TestStreamEventStreamAsAnthropicAssistantToolSnapshotReplacesBufferedSameID(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_same_id_stream_first",
+			"name":      "custom_tool",
+			"input":     `{"value":"stale-stream"}`,
+		},
+	}))
+	_, _ = stream.Write(buildEventStreamFrame(t, "assistantResponseEvent", map[string]any{
+		"assistantResponseEvent": map[string]any{
+			"toolUses": []map[string]any{
+				{
+					"toolUseId": "toolu_same_id_stream_first",
+					"name":      "custom_tool",
+					"input":     map[string]any{"value": "snapshot"},
+				},
+			},
+		},
+	}))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+	require.NoError(t, err)
+	require.Equal(t, "tool_use", result.StopReason)
+	require.Equal(t, 1, strings.Count(out.String(), `"id":"toolu_same_id_stream_first"`))
+	require.JSONEq(t, `{"value":"snapshot"}`, extractStreamedToolInputJSON(t, out.String(), "toolu_same_id_stream_first"))
+}
+
+func TestStreamEventStreamAsAnthropicAssistantToolSnapshotRecoversInvalidStoppedStream(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_same_id_recovery",
+			"name":      "custom_tool",
+			"input":     `{"value":`,
+			"stop":      true,
+		},
+	}))
+	_, _ = stream.Write(buildEventStreamFrame(t, "assistantResponseEvent", map[string]any{
+		"assistantResponseEvent": map[string]any{
+			"toolUses": []map[string]any{
+				{
+					"toolUseId": "toolu_same_id_recovery",
+					"name":      "custom_tool",
+					"input":     map[string]any{"value": "snapshot"},
+				},
+			},
+		},
+	}))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+	require.NoError(t, err)
+	require.Equal(t, "tool_use", result.StopReason)
+	require.Equal(t, 1, strings.Count(out.String(), `"id":"toolu_same_id_recovery"`))
+	require.JSONEq(t, `{"value":"snapshot"}`, extractStreamedToolInputJSON(t, out.String(), "toolu_same_id_recovery"))
+}
+
+func TestStreamEventStreamAsAnthropicDeduplicatesRestoredToolNamesByContent(t *testing.T) {
+	longName := strings.Repeat("long_tool_name_", 6)
+	shortName := shortenToolNameIfNeeded(longName)
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "assistantResponseEvent", map[string]any{
+		"assistantResponseEvent": map[string]any{
+			"toolUses": []map[string]any{
+				{
+					"toolUseId": "toolu_short_aggregate",
+					"name":      shortName,
+					"input":     map[string]any{"value": "same"},
+				},
+			},
+		},
+	}))
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_short_stream",
+			"name":      shortName,
+			"input":     map[string]any{"value": "same"},
+			"stop":      true,
+		},
+	}))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{
+		ToolNameMap: map[string]string{shortName: longName},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "tool_use", result.StopReason)
+	require.Equal(t, 1, strings.Count(out.String(), `"type":"tool_use"`))
+	require.Equal(t, 1, strings.Count(out.String(), `"name":"`+longName+`"`))
+}
+
+func TestStreamEventStreamAsAnthropicNormalizesWebSearchToolName(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_web_search_name",
+			"name":      "web_search",
+			"input":     `{"query":"golang"}`,
+			"stop":      true,
+		},
+	}))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "claude-sonnet-4-5", 9, KiroRequestContext{})
+	require.NoError(t, err)
+	require.Equal(t, "tool_use", result.StopReason)
+	require.Contains(t, out.String(), `"name":"remote_web_search"`)
+	require.NotContains(t, out.String(), `"name":"web_search"`)
+}
+
 func TestStreamEventStreamAsAnthropicRestoresShortToolName(t *testing.T) {
 	longName := strings.Repeat("long_tool_name_", 6)
 	shortName := shortenToolNameIfNeeded(longName)
@@ -1740,6 +2345,87 @@ func TestKiroCacheEmulationUsageInjectedIntoStreamAndResult(t *testing.T) {
 	require.Contains(t, output, `"cache_read_input_tokens":70`)
 	require.Contains(t, output, `"cache_creation_input_tokens":30`)
 	require.Contains(t, output, `"ephemeral_1h_input_tokens":30`)
+}
+
+func TestNormalizeStreamingToolInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+		raw      string
+		want     map[string]any
+		wantOK   bool
+	}{
+		{
+			name:     "repairs literal control characters and trailing comma",
+			toolName: "ExitPlanMode",
+			raw:      "{\"plan\":\"line one\nline two\t\x00\",}",
+			want:     map[string]any{"plan": "line one\nline two\t\x00"},
+			wantOK:   true,
+		},
+		{
+			name:     "preserves comma closers inside strings",
+			toolName: "ExitPlanMode",
+			raw:      "{\"plan\":\"keep ,} and ,]\nnext\",}",
+			want:     map[string]any{"plan": "keep ,} and ,]\nnext"},
+			wantOK:   true,
+		},
+		{
+			name:     "preserves backslash before literal newline",
+			toolName: "ExitPlanMode",
+			raw:      "{\"plan\":\"echo \\\nnext\"}",
+			want:     map[string]any{"plan": "echo \\\nnext"},
+			wantOK:   true,
+		},
+		{
+			name:     "preserves large integer",
+			toolName: "custom_tool",
+			raw:      `{"id":9007199254740993}`,
+			want:     map[string]any{"id": json.Number("9007199254740993")},
+			wantOK:   true,
+		},
+		{
+			name:     "accepts empty object for unknown tool",
+			toolName: "custom_tool",
+			raw:      `{}`,
+			want:     map[string]any{},
+			wantOK:   true,
+		},
+		{
+			name:     "rejects synthetically completable truncation",
+			toolName: "write_to_file",
+			raw:      `{"path":"main.go","content":"package main`,
+			wantOK:   false,
+		},
+		{
+			name:     "rejects missing required field",
+			toolName: "write_to_file",
+			raw:      `{"path":"main.go"}`,
+			wantOK:   false,
+		},
+		{name: "rejects array", toolName: "custom_tool", raw: `[]`, wantOK: false},
+		{name: "rejects scalar", toolName: "custom_tool", raw: `"value"`, wantOK: false},
+		{name: "rejects null", toolName: "custom_tool", raw: `null`, wantOK: false},
+		{name: "rejects empty input", toolName: "custom_tool", raw: ` `, wantOK: false},
+		{name: "rejects malformed syntax", toolName: "custom_tool", raw: `{"x":}`, wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalized, input, ok := normalizeStreamingToolInput(tt.toolName, tt.raw)
+			require.Equal(t, tt.wantOK, ok)
+			if !tt.wantOK {
+				require.Empty(t, normalized)
+				require.Nil(t, input)
+				return
+			}
+			require.Equal(t, tt.want, input)
+			var decoded map[string]any
+			decoder := json.NewDecoder(strings.NewReader(normalized))
+			decoder.UseNumber()
+			require.NoError(t, decoder.Decode(&decoded))
+			require.Equal(t, tt.want, decoded)
+		})
+	}
 }
 
 func TestRepairJSONKeepsStringBracesWhileRepairingTrailingComma(t *testing.T) {
@@ -2017,10 +2703,55 @@ func TestStreamEventStreamAsAnthropicUpstreamOutputTokensNotOverridden(t *testin
 	require.Contains(t, deltaSection, `"output_tokens":42`, "upstream outputTokens should not be overridden by estimation")
 }
 
+func TestStreamEventStreamAsAnthropicStopsAfterToolBlockWriteError(t *testing.T) {
+	stream := bytes.NewBuffer(buildEventStreamFrame(t, "toolUseEvent", map[string]any{
+		"toolUseEvent": map[string]any{
+			"toolUseId": "toolu_write_error",
+			"name":      "bash",
+			"input":     `{"command":"echo hello"}`,
+			"stop":      true,
+		},
+	}))
+	writeErr := errors.New("forced write failure")
+	writer := &failAfterWritesWriter{failAt: 3, err: writeErr}
+
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, writer, "claude-sonnet-4-5", 10, KiroRequestContext{})
+	require.Nil(t, result)
+	require.ErrorIs(t, err, writeErr)
+	require.Contains(t, writer.String(), `event: content_block_start`)
+	require.NotContains(t, writer.String(), `event: content_block_stop`)
+	require.NotContains(t, writer.String(), `event: message_delta`)
+	require.NotContains(t, writer.String(), `event: message_stop`)
+}
+
+type failAfterWritesWriter struct {
+	buffer bytes.Buffer
+	writes int
+	failAt int
+	err    error
+}
+
+func (w *failAfterWritesWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes == w.failAt {
+		return 0, w.err
+	}
+	return w.buffer.Write(p)
+}
+
+func (w *failAfterWritesWriter) String() string {
+	return w.buffer.String()
+}
+
 func buildEventStreamFrame(t *testing.T, eventType string, payload any) []byte {
 	t.Helper()
 	payloadBytes, err := json.Marshal(payload)
 	require.NoError(t, err)
+	return buildRawEventStreamFrame(t, eventType, payloadBytes)
+}
+
+func buildRawEventStreamFrame(t *testing.T, eventType string, payloadBytes []byte) []byte {
+	t.Helper()
 
 	headers := bytes.NewBuffer(nil)
 	_ = headers.WriteByte(byte(len(":event-type")))


### PR DESCRIPTION
- 移除未使用的正则表达式，精简变量定义
- 重新设计流式工具输入缓存，支持增量和快照模式
- 修复工具输入JSON字符串的控制字符转义和尾随逗号处理
- 规避超过允许大小的工具输入缓存，标记为无效避免错误处理
- 优化工具使用事件的开始、增量与结束流程，保证事件顺序和数据完整性
- 调整停止原因优先级逻辑，正确反映工具使用状态
- 新增isEmittableToolUse辅助函数，过滤不完整的工具使用
- 修复工具输入JSON解析中使用json.Decoder保持数字精度与格式正确
- 添加单元测试覆盖大整数、尾随JSON、快照替换、超大输入、控制字符转义等
- 测试完善工具流式断帧、多事件合并和事件过滤行为