### PR TITLE
fix(kiro): correct GPT-5.6 identity/reasoning/usage-tracking bugs

### DIFF
--- a/backend/internal/pkg/kiro/translator.go
+++ b/backend/internal/pkg/kiro/translator.go
@@ -76,6 +76,7 @@ var (
 
 type Usage struct {
 	InputTokens                int
+	InputTokensReported        bool
 	OutputTokens               int
 	TotalTokens                int
 	CacheReadInputTokens       int
@@ -83,6 +84,7 @@ type Usage struct {
 	CacheCreation5mInputTokens int
 	CacheCreation1hInputTokens int
 	KiroCredits                float64
+	realCacheUsageReported     bool
 }
 
 type StreamResult struct {
@@ -99,6 +101,7 @@ type ParseResult struct {
 
 type KiroRequestContext struct {
 	ToolNameMap              map[string]string
+	UpstreamModel            string
 	ThinkingEnabled          bool
 	CacheEmulationUsage      *Usage
 	StructuredOutputToolName string
@@ -349,6 +352,26 @@ func isKiroGPTModel(modelID string) bool {
 	}
 }
 
+// extractKiroGPTReasoningEffort 从客户端请求体中解析 GPT-5.6 的 reasoning effort。
+// 依次尝试 Responses 风格的 output_config.effort、OpenAI 风格的 reasoning_effort/
+// reasoning.effort;"max" 归一化为 Kiro 支持的最高档 "xhigh"。
+func extractKiroGPTReasoningEffort(body []byte) string {
+	effort := ""
+	for _, path := range []string{"output_config.effort", "reasoning_effort", "reasoning.effort"} {
+		if effort = strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, path).String())); effort != "" {
+			break
+		}
+	}
+	switch effort {
+	case "max":
+		return "xhigh"
+	case "low", "medium", "high", "xhigh":
+		return effort
+	default:
+		return ""
+	}
+}
+
 func kiroMaxOutputTokensForModel(model string) int {
 	normalized := normalizeModelAlias(model)
 	switch normalized {
@@ -374,7 +397,7 @@ func clampFloat(value, minValue, maxValue float64) float64 {
 }
 
 func BuildKiroPayloadWithContext(claudeBody []byte, modelID, profileArn, origin string, headers http.Header) (*KiroBuildResult, error) {
-	requestCtx := KiroRequestContext{ToolNameMap: map[string]string{}}
+	requestCtx := KiroRequestContext{ToolNameMap: map[string]string{}, UpstreamModel: modelID}
 	outputCap := kiroMaxOutputTokensForModel(firstNonEmptyString(gjson.GetBytes(claudeBody, "model").String(), modelID))
 	var maxTokens int64
 	if mt := gjson.GetBytes(claudeBody, "max_tokens"); mt.Exists() {
@@ -433,11 +456,13 @@ func BuildKiroPayloadWithContext(claudeBody []byte, modelID, profileArn, origin 
 			baseSystem = inlineSystem
 		}
 	}
+	gptReasoningEffort := ""
 	if isKiroGPTModel(modelID) {
+		gptReasoningEffort = extractKiroGPTReasoningEffort(claudeBody)
 		thinking = nil
 		requestCtx.ThinkingEnabled = false
 	}
-	systemPrompt := buildInjectedSystemPrompt(baseSystem, thinking, toolChoiceHint)
+	systemPrompt := buildInjectedSystemPrompt(baseSystem, modelID, thinking, toolChoiceHint)
 
 	history, currentUserMsg, currentToolResults := processMessages(filteredMessages, modelID, normalizeOrigin(origin), &requestCtx)
 	history = prependSystemHistory(history, systemPrompt, modelID, normalizeOrigin(origin))
@@ -507,7 +532,7 @@ func BuildKiroPayloadWithContext(claudeBody []byte, modelID, profileArn, origin 
 		},
 		ProfileArn:                   profileArn,
 		InferenceConfig:              inferenceConfig,
-		AdditionalModelRequestFields: buildAdditionalModelRequestFields(thinking, modelID),
+		AdditionalModelRequestFields: buildAdditionalModelRequestFields(thinking, modelID, gptReasoningEffort),
 	}
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
@@ -517,12 +542,13 @@ func BuildKiroPayloadWithContext(claudeBody []byte, modelID, profileArn, origin 
 }
 
 func ParseNonStreamingEventStreamWithContext(body io.Reader, model string, requestCtx KiroRequestContext) (*ParseResult, error) {
-	content, toolUses, usage, stopReason, err := parseEventStream(body)
+	isGPT := isKiroGPTModel(firstNonEmptyString(requestCtx.UpstreamModel, model))
+	content, toolUses, usage, stopReason, err := parseEventStream(body, !isGPT)
 	if err != nil {
 		return nil, err
 	}
 	if requestCtx.CacheEmulationUsage != nil {
-		usage = mergeKiroCacheEmulationUsage(usage, requestCtx.CacheEmulationUsage)
+		usage = mergeKiroCacheEmulationUsage(usage, requestCtx.CacheEmulationUsage, isGPT)
 	}
 	return &ParseResult{
 		ResponseBody: buildClaudeResponse(content, toolUses, model, usage, stopReason, requestCtx),
@@ -535,6 +561,7 @@ func StreamEventStreamAsAnthropicWithContext(ctx context.Context, body io.Reader
 	reader := bufio.NewReader(body)
 	start := time.Now()
 	var firstDelta *time.Duration
+	isGPT := isKiroGPTModel(firstNonEmptyString(requestCtx.UpstreamModel, model))
 	usage := Usage{InputTokens: inputTokens}
 	contentBlockIndex := -1
 	thinkingBlockIndex := -1
@@ -576,8 +603,13 @@ func StreamEventStreamAsAnthropicWithContext(ctx context.Context, body io.Reader
 		}
 		useMsgID := newClaudeMessageID()
 		startUsage := usage
-		if requestCtx.CacheEmulationUsage != nil {
-			startUsage = mergeKiroCacheEmulationUsage(startUsage, requestCtx.CacheEmulationUsage)
+		if isGPT {
+			// GPT-5.6 reports authoritative uncached/cache buckets in terminal
+			// metadata. Do not seed downstream accounting with an estimate that
+			// cannot later be overwritten by an explicit zero on a full cache hit.
+			startUsage.InputTokens = 0
+		} else if requestCtx.CacheEmulationUsage != nil {
+			startUsage = mergeKiroCacheEmulationUsage(startUsage, requestCtx.CacheEmulationUsage, false)
 		}
 		usageMap := map[string]any{
 			"input_tokens":  startUsage.InputTokens,
@@ -1153,7 +1185,17 @@ func StreamEventStreamAsAnthropicWithContext(ctx context.Context, body io.Reader
 			pendingAssistantText += evt.Content
 			return flushPendingAssistantText()
 		case kiroSemanticReasoning:
-			if evt.Reasoning == "" || !requestCtx.ThinkingEnabled {
+			if evt.Reasoning == "" {
+				return nil
+			}
+			if !requestCtx.ThinkingEnabled {
+				if isGPT {
+					// GPT-5.6 reasoning is never surfaced as a Claude "thinking"
+					// block, but must still count toward output-token estimation
+					// (mirrors the non-streaming suppression path) instead of
+					// being silently dropped.
+					_, _ = outputTextBuf.WriteString(evt.Reasoning)
+				}
 				return nil
 			}
 			// 连续的 reasoningContentEvent 片段累积进同一个 thinking 块。
@@ -1266,7 +1308,7 @@ func StreamEventStreamAsAnthropicWithContext(ctx context.Context, body io.Reader
 		usage.TotalTokens = usage.InputTokens + usage.OutputTokens
 	}
 	if requestCtx.CacheEmulationUsage != nil {
-		usage = mergeKiroCacheEmulationUsage(usage, requestCtx.CacheEmulationUsage)
+		usage = mergeKiroCacheEmulationUsage(usage, requestCtx.CacheEmulationUsage, isGPT)
 	}
 	switch stopReason {
 	case "max_tokens", "stop_sequence":
@@ -1436,19 +1478,41 @@ func thinkingDirectiveFromModel(model string) *thinkingDirective {
 // 这是个字面量;若不替换,模型会直接复读 "I am {{identity}}",对 Opus 4.7/4.8 这类
 // 对格式更敏感的版本尤其明显。
 //
-// identity 为空时回退到 "Claude",对齐 prompt 中 <CRITICAL_OVERRIDE> 的兜底语义:
-// "If no identity is provided, say that you are Claude."
+// identity 为空时回退到 "Claude",对齐 prompt 中 <CRITICAL_OVERRIDE> 的兜底语义。
 func renderKiroBuiltinIdentityPrompt(identity string) string {
 	identity = strings.TrimSpace(identity)
 	if identity == "" {
 		identity = "Claude"
 	}
-	return strings.ReplaceAll(kiroBuiltinIdentityPrompt, "{{identity}}", identity)
+	prompt := kiroBuiltinIdentityPrompt
+	if identity != "Claude" {
+		prompt = strings.ReplaceAll(
+			prompt,
+			"If no identity is provided, say that you are Claude.",
+			"If no identity is provided, say that you are "+identity+".",
+		)
+	}
+	return strings.ReplaceAll(prompt, "{{identity}}", identity)
 }
 
-func buildInjectedSystemPrompt(systemPrompt string, thinking *thinkingDirective, toolChoiceHint string) string {
+// kiroDefaultIdentityForModel 返回 Kiro 内置身份提示的默认身份。GPT-5.6 系列不是 Claude
+// 的重皮肤,继续用 "You are Claude" 兜底会让模型收到自相矛盾的身份指令。
+func kiroDefaultIdentityForModel(modelID string) string {
+	switch MapModel(modelID) {
+	case "gpt-5.6-sol":
+		return "GPT-5.6 Sol"
+	case "gpt-5.6-terra":
+		return "GPT-5.6 Terra"
+	case "gpt-5.6-luna":
+		return "GPT-5.6 Luna"
+	default:
+		return "Claude"
+	}
+}
+
+func buildInjectedSystemPrompt(systemPrompt, modelID string, thinking *thinkingDirective, toolChoiceHint string) string {
 	systemPrompt = strings.TrimSpace(systemPrompt)
-	promptParts := []string{renderKiroBuiltinIdentityPrompt("")}
+	promptParts := []string{renderKiroBuiltinIdentityPrompt(kiroDefaultIdentityForModel(modelID))}
 	if temporalContext := buildKiroTemporalContext(); temporalContext != "" {
 		promptParts = append(promptParts, temporalContext)
 	}
@@ -1498,14 +1562,20 @@ func buildKiroTemporalContext() string {
 }
 
 // buildAdditionalModelRequestFields 构建 Kiro payload 的 additionalModelRequestFields。
-// 对 Claude 4.6+ 模型，使用 output_config.effort 路径（官方 Kiro IDE 的 kr() 逻辑）：
+// GPT-5.6 使用 Kiro 原生 reasoning.effort；Claude 4.6+ 使用 output_config.effort：
 //
+//	GPT-5.6 → { reasoning: {effort} }
 //	output_config 路径 → { thinking: {type:'adaptive',display:'summarized'}, output_config: {effort} }
 //
 // 对于旧模型或 enabled 模式，不注入（依赖 system prompt 标签兜底）。
 //
 // 这实现了管理器的 P1 功能：确保 Claude 4.6+ 新模型的 thinking 使用 effort-based 控制。
-func buildAdditionalModelRequestFields(thinking *thinkingDirective, modelID string) map[string]any {
+func buildAdditionalModelRequestFields(thinking *thinkingDirective, modelID string, gptReasoningEffort string) map[string]any {
+	if gptReasoningEffort != "" {
+		return map[string]any{
+			"reasoning": map[string]any{"effort": gptReasoningEffort},
+		}
+	}
 	if thinking == nil {
 		return nil
 	}
@@ -2915,7 +2985,7 @@ func blockToMap(block gjson.Result) map[string]any {
 	return result
 }
 
-func parseEventStream(body io.Reader) (string, []KiroToolUse, Usage, string, error) {
+func parseEventStream(body io.Reader, includeReasoning bool) (string, []KiroToolUse, Usage, string, error) {
 	reader := bufio.NewReader(body)
 	var content strings.Builder
 	var toolUses []KiroToolUse
@@ -2923,6 +2993,7 @@ func parseEventStream(body io.Reader) (string, []KiroToolUse, Usage, string, err
 	stopReason := ""
 	processedIDs := make(map[string]bool)
 	var currentTool *toolUseState
+	var suppressedReasoning strings.Builder
 	reasoningOpen := false
 	closeReasoning := func() {
 		if reasoningOpen {
@@ -2987,6 +3058,10 @@ func parseEventStream(body io.Reader) (string, []KiroToolUse, Usage, string, err
 			if text == "" {
 				text = getString(event, "text")
 			}
+			if !includeReasoning {
+				_, _ = suppressedReasoning.WriteString(text)
+				continue
+			}
 			if text != "" {
 				// 连续 reasoning 片段累积进同一对 <thinking></thinking>，
 				// 仅在首片写开始标签，结束标签在边界（content/tool/EOF）由 closeReasoning 补上。
@@ -3019,6 +3094,7 @@ func parseEventStream(body io.Reader) (string, []KiroToolUse, Usage, string, err
 
 	if usage.OutputTokens == 0 {
 		var outputBuf strings.Builder
+		_, _ = outputBuf.WriteString(suppressedReasoning.String())
 		_, _ = outputBuf.WriteString(cleanText)
 		for _, tu := range toolUses {
 			if b, err := json.Marshal(tu.Input); err == nil {
@@ -4267,8 +4343,11 @@ func updateUsageFromEvent(usage *Usage, eventType string, event map[string]any) 
 		meta = event
 	}
 	if tokenUsage, ok := meta["tokenUsage"].(map[string]any); ok {
-		if value, ok := toInt(tokenUsage["uncachedInputTokens"]); ok {
-			usage.InputTokens = value
+		if raw, reported := tokenUsage["uncachedInputTokens"]; reported {
+			if value, ok := toInt(raw); ok && value >= 0 {
+				usage.InputTokens = value
+				usage.InputTokensReported = true
+			}
 		}
 		if value, ok := toInt(tokenUsage["outputTokens"]); ok {
 			usage.OutputTokens = value
@@ -4276,15 +4355,27 @@ func updateUsageFromEvent(usage *Usage, eventType string, event map[string]any) 
 		if value, ok := toInt(tokenUsage["totalTokens"]); ok {
 			usage.TotalTokens = value
 		}
-		if value, ok := toInt(tokenUsage["cacheReadInputTokens"]); ok {
-			usage.CacheReadInputTokens = value
+		if raw, reported := tokenUsage["cacheReadInputTokens"]; reported {
+			if value, ok := toInt(raw); ok && value >= 0 {
+				usage.CacheReadInputTokens = value
+				usage.realCacheUsageReported = true
+			}
+		}
+		if raw, reported := tokenUsage["cacheWriteInputTokens"]; reported {
+			if value, ok := toInt(raw); ok && value >= 0 {
+				usage.CacheCreationInputTokens = value
+				usage.realCacheUsageReported = true
+			}
 		}
 		updateKiroCreditsFromMap(usage, tokenUsage)
 	}
 	updateKiroCreditsFromMap(usage, event)
 	updateKiroCreditsFromMap(usage, meta)
-	if value, ok := toInt(event["inputTokens"]); ok && value > 0 {
-		usage.InputTokens = value
+	if raw, reported := event["inputTokens"]; reported {
+		if value, ok := toInt(raw); ok && value >= 0 {
+			usage.InputTokens = value
+			usage.InputTokensReported = true
+		}
 	}
 	if value, ok := toInt(event["outputTokens"]); ok && value > 0 {
 		usage.OutputTokens = value
@@ -4292,8 +4383,11 @@ func updateUsageFromEvent(usage *Usage, eventType string, event map[string]any) 
 	if value, ok := toInt(event["totalTokens"]); ok && value > 0 {
 		usage.TotalTokens = value
 	}
-	if value, ok := toInt(meta["inputTokens"]); ok && value > 0 {
-		usage.InputTokens = value
+	if raw, reported := meta["inputTokens"]; reported {
+		if value, ok := toInt(raw); ok && value >= 0 {
+			usage.InputTokens = value
+			usage.InputTokensReported = true
+		}
 	}
 	if value, ok := toInt(meta["outputTokens"]); ok && value > 0 {
 		usage.OutputTokens = value
@@ -4426,14 +4520,18 @@ func toPositiveFiniteFloat(value any) (float64, bool) {
 	return out, true
 }
 
-func mergeKiroCacheEmulationUsage(base Usage, simulated *Usage) Usage {
+func mergeKiroCacheEmulationUsage(base Usage, simulated *Usage, preserveReportedInput bool) Usage {
 	if simulated == nil {
 		return base
 	}
-	if base.CacheReadInputTokens > 0 || base.CacheCreationInputTokens > 0 || base.CacheCreation5mInputTokens > 0 || base.CacheCreation1hInputTokens > 0 {
+	if preserveReportedInput && base.InputTokensReported {
+		return base
+	}
+	if base.realCacheUsageReported || base.CacheReadInputTokens > 0 || base.CacheCreationInputTokens > 0 || base.CacheCreation5mInputTokens > 0 || base.CacheCreation1hInputTokens > 0 {
 		return base
 	}
 	base.InputTokens = simulated.InputTokens
+	base.InputTokensReported = true
 	base.CacheReadInputTokens = simulated.CacheReadInputTokens
 	base.CacheCreationInputTokens = simulated.CacheCreationInputTokens
 	base.CacheCreation5mInputTokens = simulated.CacheCreation5mInputTokens

--- a/backend/internal/pkg/kiro/translator_test.go
+++ b/backend/internal/pkg/kiro/translator_test.go
@@ -348,12 +348,70 @@ func TestBuildKiroPayloadDoesNotInjectClaudeThinkingTagsForGPTModels(t *testing.
 	require.NoError(t, err)
 
 	systemContent := gjson.GetBytes(kiroBuildResult.Payload, "conversationState.history.0.userInputMessage.content").String()
-	require.Contains(t, systemContent, "You are Claude, a senior software engineer")
+	// GPT-5.6 is not a Claude re-skin: the builtin identity prompt must not tell
+	// the model to claim a Claude identity.
+	require.Contains(t, systemContent, "You are GPT-5.6 Terra, a senior software engineer")
+	require.NotContains(t, systemContent, "You are Claude,")
 	require.NotContains(t, systemContent, "<thinking_mode>")
 	require.NotContains(t, systemContent, "<max_thinking_length>")
 	require.NotContains(t, systemContent, "<thinking_effort>")
 	require.False(t, kiroBuildResult.Context.ThinkingEnabled)
 	require.False(t, gjson.GetBytes(kiroBuildResult.Payload, "additionalModelRequestFields").Exists())
+}
+
+// GPT-5.6 does not use Claude's thinking/output_config directive path, but a
+// client-requested reasoning effort must still reach Kiro via the model's own
+// native additionalModelRequestFields.reasoning.effort field.
+func TestBuildKiroPayloadForwardsGPTReasoningEffort(t *testing.T) {
+	cases := []struct {
+		name       string
+		body       string
+		wantEffort string
+	}{
+		{
+			name:       "reasoning_effort field",
+			body:       `{"model":"gpt-5.6-sol","reasoning_effort":"high","messages":[{"role":"user","content":"hi"}]}`,
+			wantEffort: "high",
+		},
+		{
+			name:       "nested reasoning.effort field",
+			body:       `{"model":"gpt-5.6-sol","reasoning":{"effort":"low"},"messages":[{"role":"user","content":"hi"}]}`,
+			wantEffort: "low",
+		},
+		{
+			name:       "responses-style output_config.effort field",
+			body:       `{"model":"gpt-5.6-sol","output_config":{"effort":"medium"},"messages":[{"role":"user","content":"hi"}]}`,
+			wantEffort: "medium",
+		},
+		{
+			name:       "max normalizes to xhigh",
+			body:       `{"model":"gpt-5.6-sol","reasoning_effort":"max","messages":[{"role":"user","content":"hi"}]}`,
+			wantEffort: "xhigh",
+		},
+		{
+			name:       "unrecognized effort is dropped",
+			body:       `{"model":"gpt-5.6-sol","reasoning_effort":"ultra","messages":[{"role":"user","content":"hi"}]}`,
+			wantEffort: "",
+		},
+		{
+			name:       "no effort requested",
+			body:       `{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"hi"}]}`,
+			wantEffort: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := BuildKiroPayloadWithContext([]byte(tc.body), "gpt-5.6-sol", "", "AI_EDITOR", nil)
+			require.NoError(t, err)
+			if tc.wantEffort == "" {
+				require.False(t, gjson.GetBytes(result.Payload, "additionalModelRequestFields").Exists())
+				return
+			}
+			require.Equal(t, tc.wantEffort, gjson.GetBytes(result.Payload, "additionalModelRequestFields.reasoning.effort").String())
+			require.False(t, gjson.GetBytes(result.Payload, "additionalModelRequestFields.thinking").Exists())
+		})
+	}
 }
 
 func TestBuildKiroPayloadInjectsAdaptiveThinkingForOpus46ThinkingModel(t *testing.T) {
@@ -682,6 +740,24 @@ func TestParseNonStreamingEventStreamCapturesKiroCredits(t *testing.T) {
 	require.False(t, gjson.GetBytes(result.ResponseBody, "usage._sub2api_kiro_credits").Exists())
 }
 
+// A legacy (non-tokenUsage) inputTokens event reporting an explicit 0 must win
+// over a stale nonzero value from an earlier event in the same stream, instead
+// of being treated as absent and silently ignored.
+func TestUpdateUsageFromEventPreservesReportedZeroLegacyInputTokens(t *testing.T) {
+	var usage Usage
+	updateUsageFromEvent(&usage, "messageMetadataEvent", map[string]any{
+		"inputTokens": 42,
+	})
+	require.Equal(t, 42, usage.InputTokens)
+	require.True(t, usage.InputTokensReported)
+
+	updateUsageFromEvent(&usage, "messageMetadataEvent", map[string]any{
+		"inputTokens": 0,
+	})
+	require.Equal(t, 0, usage.InputTokens)
+	require.True(t, usage.InputTokensReported)
+}
+
 func TestUpdateUsageFromEventCapturesKiroCreditsAliases(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -984,6 +1060,40 @@ func TestParseNonStreamingEventStreamMergesManyReasoningFragments(t *testing.T) 
 	require.Equal(t, "text", gjson.GetBytes(result.ResponseBody, "content.1.type").String())
 	require.Equal(t, "answer", gjson.GetBytes(result.ResponseBody, "content.1.text").String())
 	require.False(t, gjson.GetBytes(result.ResponseBody, "content.2").Exists())
+}
+
+// GPT-5.6 reasoning must never surface as a Claude "thinking" content block
+// (that's a Claude-specific response shape), but the suppressed reasoning text
+// must still count toward the output-token fallback estimate instead of being
+// silently discarded when Kiro doesn't report an authoritative output count.
+func TestParseNonStreamingEventStreamSuppressesGPTReasoningIntoOutputEstimate(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	for _, frag := range []string{"I ", "need ", "to ", "think"} {
+		_, _ = stream.Write(buildEventStreamFrame(t, "reasoningContentEvent", map[string]any{
+			"reasoningContentEvent": map[string]any{"text": frag},
+		}))
+	}
+	_, _ = stream.Write(buildEventStreamFrame(t, "assistantResponseEvent", map[string]any{
+		"assistantResponseEvent": map[string]any{"content": "answer"},
+	}))
+
+	result, err := ParseNonStreamingEventStreamWithContext(stream, "gpt-5.6-terra", KiroRequestContext{})
+	require.NoError(t, err)
+	require.Equal(t, "text", gjson.GetBytes(result.ResponseBody, "content.0.type").String())
+	require.Equal(t, "answer", gjson.GetBytes(result.ResponseBody, "content.0.text").String())
+	require.False(t, gjson.GetBytes(result.ResponseBody, "content.1").Exists())
+	require.NotContains(t, string(result.ResponseBody), "thinking")
+	require.Greater(t, result.Usage.OutputTokens, 0)
+
+	// Compare against a run with the reasoning stripped entirely: the estimate
+	// with reasoning present must be larger, proving it wasn't dropped.
+	baseline := bytes.NewBuffer(nil)
+	_, _ = baseline.Write(buildEventStreamFrame(t, "assistantResponseEvent", map[string]any{
+		"assistantResponseEvent": map[string]any{"content": "answer"},
+	}))
+	baselineResult, err := ParseNonStreamingEventStreamWithContext(baseline, "gpt-5.6-terra", KiroRequestContext{})
+	require.NoError(t, err)
+	require.Greater(t, result.Usage.OutputTokens, baselineResult.Usage.OutputTokens)
 }
 
 func TestStreamEventStreamAsAnthropicExtractsEmbeddedToolCall(t *testing.T) {
@@ -1948,6 +2058,24 @@ func TestStreamEventStreamAsAnthropicIgnoresReasoningContentWhenThinkingDisabled
 	require.NotContains(t, out.String(), `"type":"thinking"`)
 }
 
+// Streaming must not silently drop GPT-5.6 reasoning content: it stays out of
+// the visible SSE output (never a "thinking" block, matching the non-streaming
+// suppression behavior) but must still count toward the output-token fallback
+// estimate used when Kiro doesn't report an authoritative output count.
+func TestStreamEventStreamAsAnthropicCountsSuppressedGPTReasoningTowardOutputEstimate(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "reasoningContentEvent", map[string]any{
+		"reasoningContentEvent": map[string]any{"text": "a very long hidden chain of thought"},
+	}))
+
+	var out bytes.Buffer
+	result, err := StreamEventStreamAsAnthropicWithContext(context.Background(), stream, &out, "gpt-5.6-terra", 9, KiroRequestContext{})
+	require.NoError(t, err)
+	require.NotContains(t, out.String(), "hidden chain of thought")
+	require.NotContains(t, out.String(), `"type":"thinking"`)
+	require.Greater(t, result.Usage.OutputTokens, 0)
+}
+
 func TestBuildAssistantMessageStructUsesSpacePlaceholderForToolOnly(t *testing.T) {
 	msg := gjson.Parse(`{
 		"role":"assistant",
@@ -2444,6 +2572,75 @@ func TestKiroCacheEmulationUsageInjectedIntoStreamAndResult(t *testing.T) {
 	require.Contains(t, output, `"cache_read_input_tokens":70`)
 	require.Contains(t, output, `"cache_creation_input_tokens":30`)
 	require.Contains(t, output, `"ephemeral_1h_input_tokens":30`)
+}
+
+// An authoritative cacheReadInputTokens/cacheWriteInputTokens of 0 means Kiro
+// confirmed no real cache activity happened; that must not be indistinguishable
+// from the field being absent, and must suppress the client-side cache-emulation
+// overlay instead of letting it silently paper over the authoritative zero.
+func TestKiroCacheEmulationUsageDoesNotOverrideAuthoritativeZeroCacheUsage(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "messageMetadataEvent", map[string]any{
+		"messageMetadataEvent": map[string]any{
+			"tokenUsage": map[string]any{
+				"uncachedInputTokens":  120,
+				"outputTokens":         7,
+				"cacheReadInputTokens": 0,
+			},
+		},
+	}))
+	result, err := ParseNonStreamingEventStreamWithContext(stream, "claude-sonnet-4-5", KiroRequestContext{
+		CacheEmulationUsage: &Usage{
+			InputTokens:              20,
+			CacheReadInputTokens:     70,
+			CacheCreationInputTokens: 30,
+		},
+	})
+	require.NoError(t, err)
+	// Authoritative zero must win over the simulated nonzero cache guess.
+	require.Equal(t, 0, result.Usage.CacheReadInputTokens)
+	require.Equal(t, 0, result.Usage.CacheCreationInputTokens)
+	require.Equal(t, 120, result.Usage.InputTokens)
+}
+
+// cacheWriteInputTokens was previously never read at all; a real cache-creation
+// report from Kiro must populate CacheCreationInputTokens.
+func TestUpdateUsageFromEventCapturesCacheWriteInputTokens(t *testing.T) {
+	var usage Usage
+	updateUsageFromEvent(&usage, "messageMetadataEvent", map[string]any{
+		"messageMetadataEvent": map[string]any{
+			"tokenUsage": map[string]any{
+				"cacheWriteInputTokens": 45,
+			},
+		},
+	})
+	require.Equal(t, 45, usage.CacheCreationInputTokens)
+}
+
+// Once GPT-5.6 authoritatively reports its input token count, that snapshot is
+// treated as complete: client-side cache emulation must not be layered on top,
+// even though it would otherwise apply to Claude models via the same code path.
+func TestKiroCacheEmulationUsagePreservesReportedInputForGPTModel(t *testing.T) {
+	stream := bytes.NewBuffer(nil)
+	_, _ = stream.Write(buildEventStreamFrame(t, "messageMetadataEvent", map[string]any{
+		"messageMetadataEvent": map[string]any{
+			"tokenUsage": map[string]any{
+				"uncachedInputTokens": 500,
+				"outputTokens":        7,
+			},
+		},
+	}))
+	result, err := ParseNonStreamingEventStreamWithContext(stream, "gpt-5.6-terra", KiroRequestContext{
+		CacheEmulationUsage: &Usage{
+			InputTokens:              20,
+			CacheReadInputTokens:     70,
+			CacheCreationInputTokens: 30,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 500, result.Usage.InputTokens)
+	require.Equal(t, 0, result.Usage.CacheReadInputTokens)
+	require.Equal(t, 0, result.Usage.CacheCreationInputTokens)
 }
 
 func TestNormalizeStreamingToolInput(t *testing.T) {

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -115,8 +115,8 @@ func (s *GatewayService) ForwardAsChatCompletions(
 		if parsed != nil {
 			group = parsed.Group
 		}
-		cacheUsage := s.buildKiroChatCompletionsCacheEmulationUsage(ctx, account, group, body, mappedModel, estimateKiroInputTokens(ctx, anthropicBody))
-		resp, _, err = s.openKiroAnthropicStreamResponse(ctx, account, parsed, anthropicBody, mappedModel, originalModel, c.Request.Header, group, cacheUsage)
+		cachePlan := s.prepareKiroChatCompletionsCacheEmulationUsage(ctx, account, group, body, mappedModel, estimateKiroInputTokens(ctx, anthropicBody))
+		resp, _, err = s.openKiroAnthropicStreamResponse(ctx, account, parsed, anthropicBody, mappedModel, originalModel, c.Request.Header, group, cachePlan)
 		if err != nil {
 			safeErr := sanitizeUpstreamErrorMessage(err.Error())
 			setOpsUpstreamError(c, 0, safeErr, "")
@@ -335,14 +335,13 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 		return nil, fmt.Errorf("upstream stream ended without response")
 	}
 
-	// Update usage from accumulated delta
-	if usage.InputTokens > 0 || usage.OutputTokens > 0 {
-		finalResp.Usage = apicompat.AnthropicUsage{
-			InputTokens:              usage.InputTokens,
-			OutputTokens:             usage.OutputTokens,
-			CacheCreationInputTokens: usage.CacheCreationInputTokens,
-			CacheReadInputTokens:     usage.CacheReadInputTokens,
-		}
+	// Update usage from accumulated delta. Unconditional: a cache-only response
+	// (zero input/output tokens but nonzero cache read/write) must not be dropped.
+	finalResp.Usage = apicompat.AnthropicUsage{
+		InputTokens:              usage.InputTokens,
+		OutputTokens:             usage.OutputTokens,
+		CacheCreationInputTokens: usage.CacheCreationInputTokens,
+		CacheReadInputTokens:     usage.CacheReadInputTokens,
 	}
 
 	// Chain: Anthropic → Responses → Chat Completions

--- a/backend/internal/service/gateway_forward_as_chat_completions_cache_only_test.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_cache_only_test.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// A cache-only response (zero input/output tokens, nonzero cache read/write —
+// e.g. a full prompt-cache hit with no new completion tokens billed) must not
+// have its usage dropped entirely by the accumulated-delta guard.
+//
+// Kept in its own untagged file (rather than gateway_forward_as_chat_completions_test.go,
+// which is //go:build unit) so it compiles and runs independently of that
+// file's pre-existing, unrelated build breakage.
+func TestHandleCCBufferedFromAnthropic_PreservesCacheOnlyUsage(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	resp := &http.Response{
+		Header: http.Header{"x-request-id": []string{"rid_cc_cache_only"}},
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			`event: message_start`,
+			`data: {"type":"message_start","message":{"id":"msg_cache_only","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4.5","stop_reason":"","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":9,"cache_creation_input_tokens":0}}}`,
+			``,
+			`event: content_block_start`,
+			`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"ok"}}`,
+			``,
+			`event: message_delta`,
+			`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":0}}`,
+			``,
+		}, "\n"))),
+	}
+
+	svc := &GatewayService{}
+	result, err := svc.handleCCBufferedFromAnthropic(resp, c, "gpt-5", "claude-sonnet-4.5", nil, time.Now())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 0, result.Usage.InputTokens)
+	require.Equal(t, 0, result.Usage.OutputTokens)
+	require.Equal(t, 9, result.Usage.CacheReadInputTokens)
+}

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -121,8 +121,8 @@ func (s *GatewayService) ForwardAsResponses(
 		if parsed != nil {
 			group = parsed.Group
 		}
-		cacheUsage := s.buildKiroResponsesCacheEmulationUsage(ctx, account, group, body, mappedModel, estimateKiroInputTokens(ctx, anthropicBody))
-		resp, _, err = s.openKiroAnthropicStreamResponse(ctx, account, parsed, anthropicBody, mappedModel, originalModel, c.Request.Header, group, cacheUsage)
+		cachePlan := s.prepareKiroResponsesCacheEmulationUsage(ctx, account, group, body, mappedModel, estimateKiroInputTokens(ctx, anthropicBody))
+		resp, _, err = s.openKiroAnthropicStreamResponse(ctx, account, parsed, anthropicBody, mappedModel, originalModel, c.Request.Header, group, cachePlan)
 		if err != nil {
 			safeErr := sanitizeUpstreamErrorMessage(err.Error())
 			setOpsUpstreamError(c, 0, safeErr, "")
@@ -464,14 +464,13 @@ func (s *GatewayService) handleResponsesBufferedStreamingResponse(
 		return nil, fmt.Errorf("upstream stream ended without response")
 	}
 
-	// Update usage from accumulated delta
-	if usage.InputTokens > 0 || usage.OutputTokens > 0 {
-		finalResp.Usage = apicompat.AnthropicUsage{
-			InputTokens:              usage.InputTokens,
-			OutputTokens:             usage.OutputTokens,
-			CacheCreationInputTokens: usage.CacheCreationInputTokens,
-			CacheReadInputTokens:     usage.CacheReadInputTokens,
-		}
+	// Update usage from accumulated delta. Unconditional: a cache-only response
+	// (zero input/output tokens but nonzero cache read/write) must not be dropped.
+	finalResp.Usage = apicompat.AnthropicUsage{
+		InputTokens:              usage.InputTokens,
+		OutputTokens:             usage.OutputTokens,
+		CacheCreationInputTokens: usage.CacheCreationInputTokens,
+		CacheReadInputTokens:     usage.CacheReadInputTokens,
 	}
 
 	// Convert to Responses format

--- a/backend/internal/service/gateway_forward_as_responses_cache_only_test.go
+++ b/backend/internal/service/gateway_forward_as_responses_cache_only_test.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// A cache-only response (zero input/output tokens, nonzero cache read/write —
+// e.g. a full prompt-cache hit with no new completion tokens billed) must not
+// have its usage dropped entirely by the accumulated-delta guard.
+//
+// Kept in its own untagged file (rather than gateway_forward_as_responses_test.go,
+// which is //go:build unit) so it compiles and runs independently of that
+// file's pre-existing, unrelated build breakage.
+func TestHandleResponsesBufferedStreamingResponse_PreservesCacheOnlyUsage(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	resp := &http.Response{
+		Header: http.Header{"x-request-id": []string{"rid_buffered_cache_only"}},
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			`event: message_start`,
+			`data: {"type":"message_start","message":{"id":"msg_cache_only","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4.5","stop_reason":"","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":9,"cache_creation_input_tokens":0}}}`,
+			``,
+			`event: content_block_start`,
+			`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"ok"}}`,
+			``,
+			`event: message_delta`,
+			`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":0}}`,
+			``,
+		}, "\n"))),
+	}
+
+	svc := &GatewayService{}
+	result, err := svc.handleResponsesBufferedStreamingResponse(resp, c, "claude-sonnet-4.5", "claude-sonnet-4.5", nil, time.Now(), apicompat.ResponsesClientToolMapping{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 0, result.Usage.InputTokens)
+	require.Equal(t, 0, result.Usage.OutputTokens)
+	require.Equal(t, 9, result.Usage.CacheReadInputTokens)
+}

--- a/backend/internal/service/kiro_cache_emulation.go
+++ b/backend/internal/service/kiro_cache_emulation.go
@@ -52,7 +52,36 @@ type kiroCacheTracker struct {
 
 var globalKiroCacheTracker = &kiroCacheTracker{entries: make(map[uint64]map[[32]byte]kiroCacheEntry)}
 
+// kiroCacheEmulationPlan 把缓存估算拆成"计算"与"落盘"两步：compute() 只读,
+// commit() 才会把本次前缀写入 tracker。调用方应在确认上游请求成功后再 commit(),
+// 避免请求失败/未发出时就把内容错误标记为已缓存。
+type kiroCacheEmulationPlan struct {
+	usage    *kiroCacheEmulationUsage
+	cacheKey uint64
+	profile  *kiroCacheProfile
+}
+
+func (p *kiroCacheEmulationPlan) result() *kiroCacheEmulationUsage {
+	if p == nil {
+		return nil
+	}
+	return p.usage
+}
+
+func (p *kiroCacheEmulationPlan) commit() {
+	if p == nil || p.profile == nil || p.cacheKey == 0 {
+		return
+	}
+	globalKiroCacheTracker.update(p.cacheKey, p.profile)
+}
+
 func (s *GatewayService) buildKiroCacheEmulationUsage(ctx context.Context, account *Account, group *Group, body []byte, model string, inputTokens int) *kiroCacheEmulationUsage {
+	plan := s.prepareKiroCacheEmulationUsage(ctx, account, group, body, model, inputTokens)
+	plan.commit()
+	return plan.result()
+}
+
+func (s *GatewayService) prepareKiroCacheEmulationUsage(ctx context.Context, account *Account, group *Group, body []byte, model string, inputTokens int) *kiroCacheEmulationPlan {
 	NormalizeGroupRuntimeFields(group)
 	if group == nil || !group.EffectiveKiroCacheEmulationEnabled() || account == nil || account.ID <= 0 || len(body) == 0 {
 		return nil
@@ -61,10 +90,16 @@ func (s *GatewayService) buildKiroCacheEmulationUsage(ctx context.Context, accou
 	if !ok {
 		return nil
 	}
-	return s.buildKiroCacheEmulationUsageFromProfile(account, group, profile, inputTokens)
+	return s.prepareKiroCacheEmulationPlanFromProfile(account, group, profile, inputTokens)
 }
 
 func (s *GatewayService) buildKiroResponsesCacheEmulationUsage(ctx context.Context, account *Account, group *Group, body []byte, model string, inputTokens int) *kiroCacheEmulationUsage {
+	plan := s.prepareKiroResponsesCacheEmulationUsage(ctx, account, group, body, model, inputTokens)
+	plan.commit()
+	return plan.result()
+}
+
+func (s *GatewayService) prepareKiroResponsesCacheEmulationUsage(ctx context.Context, account *Account, group *Group, body []byte, model string, inputTokens int) *kiroCacheEmulationPlan {
 	NormalizeGroupRuntimeFields(group)
 	if group == nil || !group.EffectiveKiroCacheEmulationEnabled() || account == nil || account.ID <= 0 || len(body) == 0 {
 		return nil
@@ -73,10 +108,16 @@ func (s *GatewayService) buildKiroResponsesCacheEmulationUsage(ctx context.Conte
 	if !ok {
 		return nil
 	}
-	return s.buildKiroCacheEmulationUsageFromProfile(account, group, profile, inputTokens)
+	return s.prepareKiroCacheEmulationPlanFromProfile(account, group, profile, inputTokens)
 }
 
 func (s *GatewayService) buildKiroChatCompletionsCacheEmulationUsage(ctx context.Context, account *Account, group *Group, body []byte, model string, inputTokens int) *kiroCacheEmulationUsage {
+	plan := s.prepareKiroChatCompletionsCacheEmulationUsage(ctx, account, group, body, model, inputTokens)
+	plan.commit()
+	return plan.result()
+}
+
+func (s *GatewayService) prepareKiroChatCompletionsCacheEmulationUsage(ctx context.Context, account *Account, group *Group, body []byte, model string, inputTokens int) *kiroCacheEmulationPlan {
 	NormalizeGroupRuntimeFields(group)
 	if group == nil || !group.EffectiveKiroCacheEmulationEnabled() || account == nil || account.ID <= 0 || len(body) == 0 {
 		return nil
@@ -89,10 +130,10 @@ func (s *GatewayService) buildKiroChatCompletionsCacheEmulationUsage(ctx context
 	if effectiveInputTokens <= 0 {
 		effectiveInputTokens = profile.totalInputTokens
 	}
-	return s.buildKiroCacheEmulationUsageFromProfile(account, group, profile, effectiveInputTokens)
+	return s.prepareKiroCacheEmulationPlanFromProfile(account, group, profile, effectiveInputTokens)
 }
 
-func (s *GatewayService) buildKiroCacheEmulationUsageFromProfile(account *Account, group *Group, profile *kiroCacheProfile, inputTokens int) *kiroCacheEmulationUsage {
+func (s *GatewayService) prepareKiroCacheEmulationPlanFromProfile(account *Account, group *Group, profile *kiroCacheProfile, inputTokens int) *kiroCacheEmulationPlan {
 	if group == nil || account == nil || account.ID <= 0 || profile == nil {
 		return nil
 	}
@@ -101,7 +142,6 @@ func (s *GatewayService) buildKiroCacheEmulationUsageFromProfile(account *Accoun
 		return nil
 	}
 	result := globalKiroCacheTracker.compute(cacheKey, profile)
-	globalKiroCacheTracker.update(cacheKey, profile)
 	ratio := group.EffectiveKiroCacheEmulationRatio()
 	result.CacheReadInputTokens = scaleKiroCacheTokens(result.CacheReadInputTokens, ratio)
 	result.CacheCreationInputTokens = scaleKiroCacheTokens(result.CacheCreationInputTokens, ratio)
@@ -112,9 +152,9 @@ func (s *GatewayService) buildKiroCacheEmulationUsageFromProfile(account *Accoun
 		result.InputTokens = 0
 	}
 	if result.CacheReadInputTokens == 0 && result.CacheCreationInputTokens == 0 {
-		return nil
+		result = nil
 	}
-	return result
+	return &kiroCacheEmulationPlan{usage: result, cacheKey: cacheKey, profile: profile}
 }
 
 func scaleKiroCacheTokens(tokens int, ratio float64) int {

--- a/backend/internal/service/kiro_cache_emulation_test.go
+++ b/backend/internal/service/kiro_cache_emulation_test.go
@@ -47,6 +47,42 @@ func TestKiroCacheEmulationUsesSnapshotGroupWithoutRepo(t *testing.T) {
 	}
 }
 
+// prepareKiroCacheEmulationUsage must not mutate the tracker until commit() is
+// called: computing a plan twice without committing should observe the exact
+// same (miss) state both times, since neither call ever wrote a cache entry.
+func TestKiroCacheEmulationPrepareDoesNotMutateUntilCommit(t *testing.T) {
+	resetKiroCacheTracker()
+	svc := &GatewayService{}
+	account := &Account{ID: 55, Platform: PlatformKiro}
+	group := kiroCacheGroup(1)
+	body := kiroCacheRequestBody("deferred commit", false)
+
+	planA := svc.prepareKiroCacheEmulationUsage(context.Background(), account, group, body, "claude-sonnet-4-6", 2000)
+	require.NotNil(t, planA)
+	usageA := planA.result()
+	require.NotNil(t, usageA)
+	require.Equal(t, 2000, usageA.CacheCreationInputTokens)
+	require.Equal(t, 0, usageA.CacheReadInputTokens)
+
+	// Not committed: a second prepare for the same content must still observe
+	// a miss, proving the first prepare() never wrote to the tracker.
+	planB := svc.prepareKiroCacheEmulationUsage(context.Background(), account, group, body, "claude-sonnet-4-6", 2000)
+	require.NotNil(t, planB)
+	usageB := planB.result()
+	require.NotNil(t, usageB)
+	require.Equal(t, 2000, usageB.CacheCreationInputTokens)
+	require.Equal(t, 0, usageB.CacheReadInputTokens)
+
+	// Now commit; a subsequent prepare should observe a cache hit.
+	planB.commit()
+	planC := svc.prepareKiroCacheEmulationUsage(context.Background(), account, group, body, "claude-sonnet-4-6", 2000)
+	require.NotNil(t, planC)
+	usageC := planC.result()
+	require.NotNil(t, usageC)
+	require.Equal(t, 2000, usageC.CacheReadInputTokens)
+	require.Equal(t, 0, usageC.CacheCreationInputTokens)
+}
+
 func TestKiroCacheEmulationRatioScalesTokens(t *testing.T) {
 	resetKiroCacheTracker()
 	svc := &GatewayService{}

--- a/backend/internal/service/kiro_runtime.go
+++ b/backend/internal/service/kiro_runtime.go
@@ -273,7 +273,7 @@ func (s *GatewayService) forwardKiroMessages(ctx context.Context, c *gin.Context
 	}, nil
 }
 
-func (s *GatewayService) openKiroAnthropicStreamResponse(ctx context.Context, account *Account, parsed *ParsedRequest, anthropicBody []byte, mappedModel, requestModel string, headers http.Header, group *Group, cacheUsageOverride *kiroCacheEmulationUsage) (*http.Response, int, error) {
+func (s *GatewayService) openKiroAnthropicStreamResponse(ctx context.Context, account *Account, parsed *ParsedRequest, anthropicBody []byte, mappedModel, requestModel string, headers http.Header, group *Group, cachePlanOverride *kiroCacheEmulationPlan) (*http.Response, int, error) {
 	token, tokenType, err := s.GetAccessToken(ctx, account)
 	if err != nil {
 		return nil, 0, err
@@ -284,17 +284,22 @@ func (s *GatewayService) openKiroAnthropicStreamResponse(ctx context.Context, ac
 		return nil, 0, fmt.Errorf("kiro requires oauth or apikey token, got %s", tokenType)
 	}
 
+	// 客户端断开不应取消仍在收集计费用量的上游读取;detachStreamUpstreamContext
+	// 让上游请求/流式读取脱离客户端请求 ctx 的取消传播,与其它 gateway 转发路径一致。
+	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, true)
+	defer releaseUpstreamCtx()
+
 	inputTokens := estimateKiroInputTokens(ctx, anthropicBody)
 	if isOnlyWebSearchToolInBody(anthropicBody) {
-		cacheUsage := cacheUsageOverride
-		if cacheUsage == nil {
-			cacheUsage = s.buildKiroCacheEmulationUsage(ctx, account, group, anthropicBody, mappedModel, inputTokens)
+		plan := cachePlanOverride
+		if plan == nil {
+			plan = s.prepareKiroCacheEmulationUsage(ctx, account, group, anthropicBody, mappedModel, inputTokens)
 		}
 		pr, pw := io.Pipe()
 		headers := make(http.Header)
 		headers.Set("Content-Type", "text/event-stream")
 		go func() {
-			streamErr := s.streamKiroWebSearchAsAnthropic(ctx, account, anthropicBody, mappedModel, requestModel, token, inputTokens, headers, pw, cacheUsage)
+			streamErr := s.streamKiroWebSearchAsAnthropic(upstreamCtx, account, anthropicBody, mappedModel, requestModel, token, inputTokens, headers, pw, plan)
 			if streamErr != nil {
 				_ = pw.CloseWithError(streamErr)
 				return
@@ -308,7 +313,7 @@ func (s *GatewayService) openKiroAnthropicStreamResponse(ctx context.Context, ac
 		}, inputTokens, nil
 	}
 
-	resp, requestCtx, err := s.executeKiroUpstreamWithParsed(ctx, account, parsed, anthropicBody, mappedModel, requestModel, token, headers)
+	resp, requestCtx, err := s.executeKiroUpstreamWithParsed(upstreamCtx, account, parsed, anthropicBody, mappedModel, requestModel, token, headers)
 	if err != nil {
 		var failoverErr *UpstreamFailoverError
 		if errors.As(err, &failoverErr) {
@@ -319,11 +324,13 @@ func (s *GatewayService) openKiroAnthropicStreamResponse(ctx context.Context, ac
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return resp, inputTokens, nil
 	}
-	cacheUsage := cacheUsageOverride
-	if cacheUsage == nil {
-		cacheUsage = s.buildKiroCacheEmulationUsage(ctx, account, group, anthropicBody, mappedModel, inputTokens)
+	plan := cachePlanOverride
+	if plan == nil {
+		plan = s.prepareKiroCacheEmulationUsage(ctx, account, group, anthropicBody, mappedModel, inputTokens)
 	}
-	requestCtx.CacheEmulationUsage = cacheUsage.toKiroUsage()
+	// 请求已确认成功(2xx),此时提交缓存前缀落盘才是安全的。
+	plan.commit()
+	requestCtx.CacheEmulationUsage = plan.result().toKiroUsage()
 
 	pr, pw := io.Pipe()
 	wrappedHeaders := resp.Header.Clone()
@@ -334,7 +341,7 @@ func (s *GatewayService) openKiroAnthropicStreamResponse(ctx context.Context, ac
 
 	go func() {
 		defer func() { _ = resp.Body.Close() }()
-		_, streamErr := kiropkg.StreamEventStreamAsAnthropicWithContext(ctx, resp.Body, pw, requestModel, inputTokens, requestCtx)
+		_, streamErr := kiropkg.StreamEventStreamAsAnthropicWithContext(upstreamCtx, resp.Body, pw, requestModel, inputTokens, requestCtx)
 		if streamErr != nil {
 			_, _ = io.WriteString(pw, "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"stream interrupted\"}}\n\n")
 			_ = pw.CloseWithError(streamErr)

--- a/backend/internal/service/kiro_websearch.go
+++ b/backend/internal/service/kiro_websearch.go
@@ -106,7 +106,7 @@ func writeAnthropicMessageStart(w io.Writer, msgID, model string, inputTokens in
 }
 
 func (s *GatewayService) streamKiroWebSearchAsAnthropic(
-	ctx context.Context, account *Account, anthropicBody []byte, mappedModel, requestModel, token string, inputTokens int, headers http.Header, w io.Writer, cacheUsage *kiroCacheEmulationUsage,
+	ctx context.Context, account *Account, anthropicBody []byte, mappedModel, requestModel, token string, inputTokens int, headers http.Header, w io.Writer, plan *kiroCacheEmulationPlan,
 ) error {
 	query := kiropkg.ExtractSearchQuery(anthropicBody)
 	if strings.TrimSpace(query) == "" {
@@ -120,7 +120,7 @@ func (s *GatewayService) streamKiroWebSearchAsAnthropic(
 	currentToolUseID := "srvtoolu_" + kiropkg.GenerateToolUseID()
 	nextContentBlockIndex := 0
 
-	if err := writeAnthropicMessageStart(w, "", requestModel, inputTokens, cacheUsage); err != nil {
+	if err := writeAnthropicMessageStart(w, "", requestModel, inputTokens, plan.result()); err != nil {
 		return err
 	}
 
@@ -151,6 +151,10 @@ func (s *GatewayService) streamKiroWebSearchAsAnthropic(
 		}
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			return &kiroWebSearchHTTPError{Response: resp}
+		}
+		if iteration == 0 {
+			// 首轮请求已确认成功,此时提交缓存前缀落盘才是安全的。
+			plan.commit()
 		}
 
 		chunks, _, streamErr := func() ([][]byte, *kiropkg.StreamResult, error) {


### PR DESCRIPTION
## Summary

Rebuilds the closed #71 as a small, focused branch on the current `main` (merge-base = `2230895db`, the exact head of `main` at the time this branch was cut). `main` already has GPT-5.6 model registration and mapping from #77; this PR only re-implements the remaining correctness fixes from #71 that are still applicable against the current code, re-verified line-by-line rather than cherry-picked.

One finding from the original review (#8, custom-alias billing) is **not** included: `main` already has a newer, more general `billableModelWithFallback` mechanism that supersedes it — falling back to the concrete forwarded model whenever the billing model has no resolvable pricing, for every platform, not just Kiro.

### Fixes

- **GPT-5.6 identity leak** — the builtin Kiro system prompt unconditionally told every model "if no identity is provided, say you are Claude". GPT-5.6 requests were being told to claim a Claude identity. Now defaults to the model's own display name (e.g. "GPT-5.6 Sol") for GPT-5.6 models.
- **GPT-5.6 reasoning effort dropped** — `additionalModelRequestFields` was derived only from the Claude `thinking` directive, which is always nil for GPT-5.6. A client-requested `reasoning_effort` (or `reasoning.effort` / `output_config.effort`) never reached Kiro. Now forwarded via Kiro's native `reasoning.effort` field, independent of the Claude thinking path.
- **Streaming vs non-streaming reasoning inconsistency** — streaming silently dropped all GPT-5.6 reasoning content; non-streaming always exposed it as a Claude `"thinking"` content block (a response shape that isn't meaningful for a non-Claude model). Both paths now keep reasoning out of the visible response consistently, while still counting the suppressed text toward the output-token fallback estimate so billing doesn't undercount when Kiro omits an authoritative output count.
- **Authoritative-zero usage indistinguishable from absent** — `updateUsageFromEvent` used to check `value > 0` to decide whether a reported token count should apply, so a legitimate authoritative `0` (e.g. "confirmed no cache read this turn") looked the same as the field being missing, and the client-side cache-emulation estimate could silently override it. `cacheWriteInputTokens` was also never read at all. `Usage` now tracks whether each field was actually reported (`InputTokensReported`, `realCacheUsageReported`), and both `mergeKiroCacheEmulationUsage` and the stream `message_start` seeding respect that.
- **Cache tracker committed before success** — `buildKiroCacheEmulationUsage` computed *and* wrote the cache-prefix entry in one step, before the upstream request was known to succeed (notably: before the request was even sent, on the request-initiation side of `/v1/responses` and `/v1/chat/completions` Kiro direct-mode paths, and in the websearch streaming branch). A failed or never-issued request would still poison the tracker for the next call. Split into `prepare()` (read-only estimate) / `commit()` (writes, called only after a confirmed 2xx, or after the first successful web-search iteration) / `result()`.
- **Client disconnect could cancel usage collection** — `openKiroAnthropicStreamResponse` read the upstream response body and ran usage parsing on the same context as the client's request. If the client disconnected before Kiro's stream reached its terminal usage event, that context cancellation aborted parsing and the request's usage was never recorded. Now uses the same `detachStreamUpstreamContext` helper already used by every other gateway forwarding path in this codebase, so a disconnect no longer interrupts in-flight usage collection.
- **Cache-only usage dropped** — the Chat Completions and Responses buffered bridges guarded `finalResp.Usage = ...` behind `usage.InputTokens > 0 || usage.OutputTokens > 0`. A cache-only turn (a full prompt-cache hit: zero new input/output tokens, nonzero cache read/write) had its entire usage silently dropped. The assignment is now unconditional (the accumulated `usage` already reflects everything merged from `message_start`/`message_delta`, so this was a pure bug, not a guard against clobbering better data).

## Scope notes

- `main`'s Kiro cache-emulation/usage-tracking code has diverged substantially from #71's base (added Responses/Chat-Completions cache-emulation paths, changed the tracker's cache-key type, and does not have the `InputTokensReported`/`realCacheUsageReported`/`cacheWriteInputTokens` machinery at all before this PR). Nothing here was cherry-picked; each fix was re-implemented against the current code after confirming the bug still reproduces.
- No changes to model registration, pricing tables, migrations, or anything outside `backend/internal/pkg/kiro/translator.go` and the six `backend/internal/service/*.go` files listed in the diff.

## Known pre-existing (baseline) issue — not touched

`internal/service/gateway_forward_as_responses_test.go` fails to compile under the `unit` build tag (`go test -tags unit ./internal/service/...`) on current `main`, independent of this PR — it references `kiroResponsesCacheUpstreamResponse`, `newResponsesGatewayTestContext`, and `gjson` symbols that don't exist anywhere in the package, and has an unused `bytes` import. Verified by stashing this branch's changes and running the same command directly against `origin/main`. Since that file couldn't be compiled, the two new cache-only-usage regression tests were placed in new, untagged sibling files (`gateway_forward_as_chat_completions_cache_only_test.go`, `gateway_forward_as_responses_cache_only_test.go`) so they can actually run; they pass.

## Test plan

- [x] `gofmt -l` clean on all touched/new files
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` (whole backend, 47 packages) — all pass
- [x] New focused regression tests, all passing:
  - `internal/pkg/kiro`: GPT-5.6 identity prompt, reasoning-effort forwarding (`reasoning_effort` / `reasoning.effort` / `output_config.effort`, `max`→`xhigh` normalization, unrecognized values dropped), streaming/non-streaming reasoning-suppression parity + output-token fallback accounting, authoritative-zero cache usage preservation, `cacheWriteInputTokens` capture, reported-zero legacy `inputTokens` preservation, GPT preserves-reported-input-over-cache-emulation behavior
  - `internal/service`: cache-emulation `prepare()` doesn't mutate the tracker until `commit()`, cache-only usage preserved in both the Chat Completions and Responses buffered bridges
- Not covered by an automated test: the disconnect-safe streaming context change in `openKiroAnthropicStreamResponse` (reuses the existing, already-adopted-elsewhere `detachStreamUpstreamContext` helper; simulating a real client disconnect mid-stream against a mocked Kiro upstream was out of scope for this pass)
- `golangci-lint` was not runnable in the sandbox this PR was prepared in (binary unavailable); relying on CI for that gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
