### PR TITLE
Improve cache hit rate calculation and enhance KiroCache functionality

### DIFF
--- a/backend/internal/pkg/kiro/fingerprint.go
+++ b/backend/internal/pkg/kiro/fingerprint.go
@@ -8,9 +8,9 @@ import (
 	"math/rand"
 	"os"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/google/uuid"
 )
@@ -115,12 +115,7 @@ func goOSToNodePlatform(goos string) string {
 }
 
 func containsString(items []string, target string) bool {
-	for _, item := range items {
-		if item == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(items, target)
 }
 
 func BuildAccountKey(clientID, clientIDHash, refreshToken, profileArn string, accountID int64) string {
@@ -257,18 +252,4 @@ func BuildLoginHeaders(accountKey, machineID string) map[string]string {
 		"User-Agent":   fmt.Sprintf("KiroIDE-%s-%s", fp.KiroVersion, fp.KiroHash),
 		"Accept":       "application/json, text/plain, */*",
 	}
-}
-
-func ExponentialBackoffWithJitter(attempt int, baseDelay, maxDelay time.Duration) time.Duration {
-	if attempt < 0 {
-		attempt = 0
-	}
-	delay := baseDelay << attempt
-	if delay > maxDelay {
-		delay = maxDelay
-	}
-	const jitterFactor = 0.3
-	seed := rand.New(rand.NewSource(time.Now().UnixNano()))
-	jitter := 1 + ((seed.Float64()*2 - 1) * jitterFactor)
-	return time.Duration(float64(delay) * jitter)
 }

--- a/backend/internal/service/kiro_cache_emulation.go
+++ b/backend/internal/service/kiro_cache_emulation.go
@@ -203,8 +203,30 @@ func scaleKiroCacheTokens(tokens int, ratio float64) int {
 }
 
 type kiroCacheProfile struct {
-	totalInputTokens              int
-	minCacheable                  int
+	totalInputTokens int
+	minCacheable     int
+	// scaleBreakpointsToInputTokens 决定断点累计值是否归一化到 totalInputTokens 所在的
+	// token 空间，三条协议路径都必须置为 true。
+	//
+	// 两侧计数口径本就不同：断点累计值由 countKiroMessageContentTokens 逐块累加，只统计
+	// text/thinking 正文；而 totalInputTokens 来自 countKiroInputTokensFromPayload，统计
+	// 的是整个 messages 的序列化 JSON，并额外计入每消息 kiroTokensPerMessage、每工具
+	// kiroTokensPerTool。后者天然包含 JSON 结构开销（字段名、role 包装、转义、tool_use 的
+	// id/name），前者对这些一律计 0。
+	//
+	// 因为 InputTokens = totalInputTokens - CacheRead - CacheCreation（见
+	// prepareKiroCacheEmulationPlanFromProfile），不归一化就等于让分子分母各用一套口径，
+	// cache_read 被系统性低估：tool_use / tool_result 密集的 Claude Code 流量里缺口可达
+	// 25%~45%，即使前缀完全命中，cache_read/totalInputTokens 也只能到 55%~75%。
+	//
+	// 归一化后最后一个可缓存断点恰好映射为 totalInputTokens，靠前断点按累计占比等比缩放。
+	// 这依赖「最后一个可缓存断点落在最后一个块上」，三条路径各有保证：
+	//   - responses / chat_completions：applyKiroDefaultBreakpoints 显式在末块放断点。
+	//   - Anthropic 且客户端下发了 cache_control：buildKiroCacheProfileFromBlocks 的消息边界
+	//     断点传播（一旦出现任一 cache_control，其后每个消息末尾都会补断点，而消息块恒排在
+	//     tools/system 之后）。
+	//   - Anthropic 且客户端未下发：buildKiroCacheProfile 的兜底同样走
+	//     applyKiroDefaultBreakpoints。
 	scaleBreakpointsToInputTokens bool
 	blocks                        []kiroCacheBlock
 	breakpoints                   []kiroCacheBreakpoint
@@ -243,6 +265,18 @@ func buildKiroCacheProfile(ctx context.Context, body []byte, model string, input
 	if len(blocks) == 0 {
 		return nil, false
 	}
+	// 客户端未下发任何 cache_control 时兜底补断点。
+	//
+	// Anthropic 路径的断点原本完全依赖客户端：无 cache_control ⇒ 无断点 ⇒
+	// lastCacheableBreakpoint 为 nil ⇒ buildKiroCacheProfileFromBlocks 返回 false ⇒ usage
+	// 为 nil，该请求零 cache_read 却仍计入命中率分母。Claude Code 会下发，但 curl、
+	// Cherry Studio 等 OpenAI 风格客户端普遍不发，这批流量是纯粹的分母污染。
+	//
+	// 只在「完全没有客户端断点」时兜底，不与客户端断点混用：若客户端已标注，额外补断点等于
+	// 在真实 API 不会缓存的位置模拟出 cache_read，会高估命中率、少计费。
+	if !hasKiroClientCacheBreakpoint(blocks) {
+		applyKiroDefaultBreakpoints(blocks, kiroCacheDefaultTTL)
+	}
 	totalTokens := inputTokens
 	if totalTokens <= 0 {
 		totalTokens = countKiroInputTokensFromPayload(ctx, payload)
@@ -251,7 +285,12 @@ func buildKiroCacheProfile(ctx context.Context, body []byte, model string, input
 		"model":       payload["model"],
 		"tool_choice": payload["tool_choice"],
 	}
-	return buildKiroCacheProfileFromBlocks(model, totalTokens, prelude, blocks)
+	profile, ok := buildKiroCacheProfileFromBlocks(model, totalTokens, prelude, blocks)
+	if ok {
+		// 与 responses / chat_completions 路径对齐，理由见 scaleBreakpointsToInputTokens。
+		profile.scaleBreakpointsToInputTokens = true
+	}
+	return profile, ok
 }
 
 func buildKiroResponsesCacheProfile(ctx context.Context, body []byte, model string, inputTokens int) (*kiroCacheProfile, bool) {
@@ -268,7 +307,7 @@ func buildKiroResponsesCacheProfile(ctx context.Context, body []byte, model stri
 		return nil, false
 	}
 	ttl := kiroCacheDefaultTTL
-	applyKiroResponsesDefaultBreakpoints(blocks, ttl)
+	applyKiroDefaultBreakpoints(blocks, ttl)
 
 	effectiveTools, err := apicompat.EffectiveResponsesTools(&req)
 	if err != nil {
@@ -308,7 +347,7 @@ func buildKiroChatCompletionsCacheProfile(ctx context.Context, body []byte, mode
 	if len(blocks) == 0 {
 		return nil, false
 	}
-	applyKiroResponsesDefaultBreakpoints(blocks, kiroCacheDefaultTTL)
+	applyKiroDefaultBreakpoints(blocks, kiroCacheDefaultTTL)
 
 	effectiveModel := strings.TrimSpace(model)
 	if effectiveModel == "" {
@@ -393,8 +432,24 @@ func flattenKiroCacheBlocks(ctx context.Context, payload map[string]any) []kiroP
 		for toolIndex, tool := range tools {
 			value := stripKiroCacheControl(tool)
 			blocks = append(blocks, kiroPendingBlock{
-				value:  map[string]any{"kind": "tool", "tool_index": toolIndex, "tool": value},
-				tokens: kiroTokensPerTool, breakpointTTL: extractKiroCacheTTL(tool),
+				value: map[string]any{"kind": "tool", "tool_index": toolIndex, "tool": value},
+				// 工具块按序列化后的真实 token 计数，不用 kiroTokensPerTool 拍平值。
+				//
+				// 真实 Claude Code 工具 schema 单个 300~1500 token，15 个工具实测约 21000，
+				// 而拍平估算只给 15*150=2250，低估约 9 倍。后果不是「命中率略低」而是
+				// 「整个 profile 被拒」：cacheableBreakpoints 用累计值与 minCacheable 比较，
+				// opus 系阈值 4096（见 kiroMinimumCacheableTokens，该值是被
+				// TestKiroMinimumCacheableTokens 钉死的显式契约，不应为此调低）。带 tools 的
+				// opus 短请求累计值卡在 2000 上下 → lastCacheableBreakpoint 为 nil →
+				// buildKiroCacheProfileFromBlocks 返回 false → 该请求零缓存，却仍然计入
+				// 命中率分母。
+				//
+				// 只改这里（B 侧）不动 countKiroInputTokensFromPayload 等计数器（T 侧）：
+				// P1 归一化后命中率 = B_matched/B_last，T 被约掉，所以修正 B 即可解决问题；
+				// 而 T 还喂给计费兜底与 count_tokens 对外契约，改动会牵连账单。两侧工具口径
+				// 因此不一致，但归一化把 B_last 精确映射到 T，该差异不会外泄。
+				tokens:        countKiroSerializedValueTokens(value),
+				breakpointTTL: extractKiroCacheTTL(tool),
 			})
 		}
 	}
@@ -567,7 +622,12 @@ func appendKiroChatCompletionsContentBlocks(ctx context.Context, blocks []kiroPe
 	return blocks
 }
 
-func applyKiroResponsesDefaultBreakpoints(blocks []kiroPendingBlock, ttl time.Duration) {
+// applyKiroDefaultBreakpoints 在每个消息末尾与最后一个块上放置断点。
+//
+// 注意它会无条件覆写 breakpointTTL。responses / chat_completions 是 OpenAI 形态、客户端
+// 不下发 cache_control，无值可覆盖；Anthropic 路径必须先用 hasKiroClientCacheBreakpoint
+// 判空后才可调用，否则会把客户端显式的 ttl:"1h" 降级成默认 5m。
+func applyKiroDefaultBreakpoints(blocks []kiroPendingBlock, ttl time.Duration) {
 	if len(blocks) == 0 {
 		return
 	}
@@ -577,6 +637,16 @@ func applyKiroResponsesDefaultBreakpoints(blocks []kiroPendingBlock, ttl time.Du
 		}
 	}
 	blocks[len(blocks)-1].breakpointTTL = &ttl
+}
+
+// hasKiroClientCacheBreakpoint 判断客户端是否下发了任何 cache_control 断点。
+func hasKiroClientCacheBreakpoint(blocks []kiroPendingBlock) bool {
+	for i := range blocks {
+		if blocks[i].breakpointTTL != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func countKiroResponsesCacheableInputItems(input []any) int {
@@ -816,6 +886,9 @@ func (t *kiroCacheTracker) compute(cacheKey uint64, profile *kiroCacheProfile) *
 			if !ok || !entry.expiresAt.After(now) {
 				continue
 			}
+			// 只续期命中的这一条即可：整条前缀链的续期由 commit() → update() 完成，
+			// 它会遍历当前 profile 的全部 cacheableBreakpoints 并推后 expiresAt，而命中点
+			// 之前的断点都属于当前 profile。此处再遍历一遍是冗余的。
 			entry.expiresAt = now.Add(entry.ttl)
 			accountEntries[candidate.prefixFingerprint] = entry
 			matchedTokens = profile.cacheTokensForBreakpoint(breakpoint.cumulativeTokens)
@@ -902,13 +975,32 @@ func (t *kiroCacheTracker) pruneLocked(now time.Time) {
 	}
 }
 
+// kiroCacheCredentialKey 返回模拟缓存 tracker 的一级命名空间键，按账号维度隔离。
+//
+// 这里必须用 account.ID，不能用凭证内容拼接，也不能用 kiropkg.BuildAccountKey：
+//   - refresh_token 会轮转。上游返回非空即覆盖写回（见 pkg/kiro/oauth.go 的 RefreshToken
+//     与 KiroOAuthService.BuildAccountCredentials），刷新窗口 kiroRefreshWindow=15min、
+//     access_token 典型 1h 有效，即每小时至少一次。凭证一旦参与计算，键就随之改变，该账号
+//     已积累的全部前缀指纹一次性作废、退回冷启动，命中率被反复打回。
+//   - client_id_hash / client_id 是「OAuth 客户端应用」标识，同一应用注册被多账号共用，
+//     会大量重复。用它做键（BuildAccountKey 的优先级短路正是先取它）会把不同账号合并进
+//     同一命名空间，产生跨账号误命中：cache_read 按 1/10 价计费而上游实际全价，属少计费，
+//     比冷启动严重得多。
+//
+// account.ID 同时满足三个必要属性：轮转时稳定、账号间唯一、恒定存在。调用方
+// prepareKiroCacheEmulationPlanFromProfile 及三个 prepare 入口均已前置校验 account.ID > 0，
+// 故此处无需兜底分支。
+//
+// 取舍：同一上游账号若被导入成两行 accounts 记录，两者不再共享缓存，会多算一次
+// cache_creation、少算 cache_read——偏保守（多计费），方向上优于误命中导致的少计费。
 func kiroCacheCredentialKey(account *Account) uint64 {
-	stableKey := strings.TrimSpace(kiroCacheCredentialIdentity(account))
-	if stableKey == "" {
+	if account == nil || account.ID <= 0 {
 		return 0
 	}
 	h := fnv.New64a()
-	_, _ = h.Write([]byte(stableKey))
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], uint64(account.ID))
+	_, _ = h.Write(buf[:])
 	return h.Sum64()
 }
 

--- a/backend/internal/service/kiro_cache_emulation_test.go
+++ b/backend/internal/service/kiro_cache_emulation_test.go
@@ -163,23 +163,48 @@ func TestKiroCacheEmulationAccountIsolation(t *testing.T) {
 	}
 }
 
-func TestKiroCacheEmulationStableCredentialIsolation(t *testing.T) {
+// 缓存命名空间按 account.ID 隔离，必须对「凭证轮转」完全免疫：access_token 与
+// refresh_token 都会在正常刷新中被覆盖写回（每小时至少一次），若参与键计算就会把该账号
+// 的全部前缀指纹作废、退回冷启动。理由详见 kiroCacheCredentialKey 的 godoc。
+func TestKiroCacheEmulationKeyIsImmuneToCredentialRotation(t *testing.T) {
 	resetKiroCacheTracker()
 	svc := &GatewayService{}
 	group := kiroCacheGroup(1)
-	body := kiroCacheRequestBody("credential isolation", false)
+	body := kiroCacheRequestBody("credential rotation", false)
+
 	first := svc.buildKiroCacheEmulationUsage(context.Background(), kiroCacheAccount(7, "refresh-same", "access-a"), group, body, "claude-sonnet-4-6", 2000)
-	if first == nil || first.CacheCreationInputTokens != 2000 {
-		t.Fatalf("unexpected first usage: %+v", first)
-	}
+	require.NotNil(t, first)
+	require.Equal(t, 2000, first.CacheCreationInputTokens)
+
 	rotatedAccessToken := svc.buildKiroCacheEmulationUsage(context.Background(), kiroCacheAccount(7, "refresh-same", "access-b"), group, body, "claude-sonnet-4-6", 2000)
-	if rotatedAccessToken == nil || rotatedAccessToken.CacheReadInputTokens != 2000 || rotatedAccessToken.CacheCreationInputTokens != 0 {
-		t.Fatalf("access token rotation should not break cache: %+v", rotatedAccessToken)
-	}
-	differentCredential := svc.buildKiroCacheEmulationUsage(context.Background(), kiroCacheAccount(7, "refresh-other", "access-c"), group, body, "claude-sonnet-4-6", 2000)
-	if differentCredential == nil || differentCredential.CacheReadInputTokens != 0 || differentCredential.CacheCreationInputTokens != 2000 {
-		t.Fatalf("different stable credential should not share cache: %+v", differentCredential)
-	}
+	require.NotNil(t, rotatedAccessToken)
+	require.Equal(t, 2000, rotatedAccessToken.CacheReadInputTokens, "access token rotation must not break cache")
+	require.Zero(t, rotatedAccessToken.CacheCreationInputTokens)
+
+	// refresh_token 轮转是每小时都会发生的正常刷新，必须仍命中同一命名空间。
+	rotatedRefreshToken := svc.buildKiroCacheEmulationUsage(context.Background(), kiroCacheAccount(7, "refresh-rotated", "access-c"), group, body, "claude-sonnet-4-6", 2000)
+	require.NotNil(t, rotatedRefreshToken)
+	require.Equal(t, 2000, rotatedRefreshToken.CacheReadInputTokens, "refresh token rotation must not break cache")
+	require.Zero(t, rotatedRefreshToken.CacheCreationInputTokens)
+}
+
+// 共用同一 OAuth 客户端应用（client_id / client_id_hash 相同）的不同账号之间不得串缓存。
+// 跨账号误命中会让 cache_read 按 1/10 价计费而上游实际全价，属少计费。
+func TestKiroCacheEmulationDoesNotShareAcrossAccountsWithSameClientID(t *testing.T) {
+	resetKiroCacheTracker()
+	svc := &GatewayService{}
+	group := kiroCacheGroup(1)
+	body := kiroCacheRequestBody("shared client id", false)
+
+	first := svc.buildKiroCacheEmulationUsage(context.Background(), kiroCacheAccount(11, "refresh-a", "access-a"), group, body, "claude-sonnet-4-6", 2000)
+	require.NotNil(t, first)
+	require.Equal(t, 2000, first.CacheCreationInputTokens)
+
+	// kiroCacheAccount 固定写入同一个 client_id，模拟共用 OAuth 应用注册的两个账号。
+	otherAccount := svc.buildKiroCacheEmulationUsage(context.Background(), kiroCacheAccount(12, "refresh-a", "access-a"), group, body, "claude-sonnet-4-6", 2000)
+	require.NotNil(t, otherAccount)
+	require.Zero(t, otherAccount.CacheReadInputTokens, "accounts sharing an OAuth client must not share cache")
+	require.Equal(t, 2000, otherAccount.CacheCreationInputTokens)
 }
 
 func TestKiroCacheEmulationContentChangeMisses(t *testing.T) {
@@ -748,4 +773,194 @@ func kiroResponsesImageCacheRequestBody(t *testing.T, label string, fill color.R
 	prompt := strings.Repeat("cacheable responses visual prompt "+label+" ", 512)
 	imageURL := kiroPNGDataURL(t, 384, 256, fill)
 	return []byte(fmt.Sprintf(`{"model":"gpt-5","instructions":"Describe visual changes precisely.","prompt_cache_key":"workspace-image","previous_response_id":"resp-image","input":[{"role":"user","content":[{"type":"input_text","text":%q},{"type":"input_image","image_url":%q}]}]}`, prompt, imageURL))
+}
+
+// 客户端完全不下发 cache_control 时（curl、Cherry Studio 等 OpenAI 风格客户端），
+// Anthropic 路径必须兜底补断点。否则该请求零 cache_read 却仍计入命中率分母。
+func TestKiroCacheEmulationFallsBackWhenClientSendsNoCacheControl(t *testing.T) {
+	resetKiroCacheTracker()
+	svc := &GatewayService{}
+	account := kiroCacheAccount(301, "refresh-nocc", "access-nocc")
+	group := kiroCacheGroup(1)
+	// 注意：整个 body 不含任何 cache_control。
+	body := []byte(fmt.Sprintf(
+		`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":[{"type":"text","text":%q}]}]}`,
+		strings.Repeat("no cache control marker anywhere in this body ", 512)))
+
+	first := svc.buildKiroCacheEmulationUsage(context.Background(), account, group, body, "claude-sonnet-4-6", 2000)
+	require.NotNil(t, first, "body without cache_control must still produce usage")
+	require.Equal(t, 2000, first.CacheCreationInputTokens)
+
+	second := svc.buildKiroCacheEmulationUsage(context.Background(), account, group, body, "claude-sonnet-4-6", 2000)
+	require.NotNil(t, second)
+	require.Equal(t, 2000, second.CacheReadInputTokens, "repeat request must hit the fallback breakpoint")
+}
+
+// 客户端显式的 ttl:"1h" 不得被兜底逻辑降级成默认 5m。
+func TestKiroCacheEmulationFallbackDoesNotDowngradeClientTTL(t *testing.T) {
+	resetKiroCacheTracker()
+	svc := &GatewayService{}
+	usage := svc.buildKiroCacheEmulationUsage(context.Background(),
+		kiroCacheAccount(302, "refresh-ttl", "access-ttl"), kiroCacheGroup(1),
+		kiroCacheRequestBody("fallback ttl", true), "claude-sonnet-4-6", 2000)
+	require.NotNil(t, usage)
+	require.Equal(t, 2000, usage.CacheCreation1hInputTokens, "client 1h TTL must survive")
+	require.Zero(t, usage.CacheCreation5mInputTokens)
+}
+
+// 带真实体积 tools 的 opus 短请求不得被 minCacheable 误拒。
+// 工具块若按 kiroTokensPerTool=150 拍平，累计值会卡在 opus 阈值 4096 之下导致 profile 被拒。
+func TestKiroCacheEmulationOpusShortRequestWithToolsIsCacheable(t *testing.T) {
+	resetKiroCacheTracker()
+	svc := &GatewayService{}
+	account := kiroCacheAccount(303, "refresh-opus", "access-opus")
+	group := kiroCacheGroup(1)
+	body := kiroToolHeavyShortRequestBody()
+
+	inputTokens := estimateKiroInputTokens(context.Background(), body)
+	first := svc.buildKiroCacheEmulationUsage(context.Background(), account, group, body, "claude-opus-4-8", inputTokens)
+	require.NotNil(t, first, "opus short request with real-sized tools must be cacheable")
+	require.Positive(t, first.CacheCreationInputTokens)
+
+	second := svc.buildKiroCacheEmulationUsage(context.Background(), account, group, body, "claude-opus-4-8", inputTokens)
+	require.NotNil(t, second)
+	require.Positive(t, second.CacheReadInputTokens, "repeat opus request must hit")
+}
+
+// commit() → update() 会遍历当前 profile 的全部可缓存断点并推后 expiresAt，
+// 因此命中后无需在 compute() 里额外遍历前缀链。这条用例把该不变量钉住。
+func TestKiroCacheEmulationCommitRenewsAllBreakpoints(t *testing.T) {
+	resetKiroCacheTracker()
+	svc := &GatewayService{}
+	account := kiroCacheAccount(304, "refresh-chain", "access-chain")
+	group := kiroCacheGroup(1)
+	body := kiroCacheMultiMessageBody("chain prefix", "chain tail")
+
+	require.NotNil(t, svc.buildKiroCacheEmulationUsage(context.Background(), account, group, body, "claude-sonnet-4-6", 6000))
+
+	cacheKey := kiroCacheCredentialKey(account)
+	nearExpiry := time.Now().Add(2 * time.Second)
+	globalKiroCacheTracker.mu.Lock()
+	entries := globalKiroCacheTracker.entries[cacheKey]
+	require.GreaterOrEqual(t, len(entries), 2, "need multiple breakpoints to exercise renewal")
+	for fp, entry := range entries {
+		entry.expiresAt = nearExpiry
+		entries[fp] = entry
+	}
+	globalKiroCacheTracker.mu.Unlock()
+
+	second := svc.buildKiroCacheEmulationUsage(context.Background(), account, group, body, "claude-sonnet-4-6", 6000)
+	require.NotNil(t, second)
+	require.Positive(t, second.CacheReadInputTokens)
+
+	globalKiroCacheTracker.mu.Lock()
+	defer globalKiroCacheTracker.mu.Unlock()
+	renewedThreshold := nearExpiry.Add(time.Minute)
+	for fp, entry := range globalKiroCacheTracker.entries[cacheKey] {
+		require.True(t, entry.expiresAt.After(renewedThreshold),
+			"entry %x was not renewed: expiresAt=%s", fp[:4], entry.expiresAt)
+	}
+}
+
+// kiroToolHeavyShortRequestBody 构造「工具多且 schema 大、但对话很短」的请求，
+// 即 Claude Code 会话刚开始时的形态。
+func kiroToolHeavyShortRequestBody() []byte {
+	desc := strings.Repeat("Detailed behavioural contract for this tool. ", 40)
+	tools := make([]string, 0, 15)
+	for i := 0; i < 15; i++ {
+		tools = append(tools, fmt.Sprintf(
+			`{"name":"tool_%d","description":%q,"input_schema":{"type":"object","properties":{"path":{"type":"string","description":%q}},"required":["path"]}}`,
+			i, desc, desc))
+	}
+	return []byte(fmt.Sprintf(
+		`{"model":"claude-opus-4-8","system":[{"type":"text","text":%q}],"tools":[%s],"messages":[{"role":"user","content":[{"type":"text","text":%q,"cache_control":{"type":"ephemeral"}}]}]}`,
+		strings.Repeat("short system. ", 8), strings.Join(tools, ","),
+		strings.Repeat("brief question. ", 10)))
+}
+
+// kiroClaudeCodeConversationBody 构造贴近真实 Claude Code 长会话的 Anthropic 请求体。
+//
+// 形态要点（决定这个用例是否具备判别力，两个约束互相拉扯，必须同时满足）：
+//   - 轮数要足够多，让 messages 在总量中占主导。若 system 相对 messages 过大，逐块计数与
+//     整体 JSON 计数之间的口径差异会被稀释，用例就测不出问题了。
+//   - 但 system 也不能过小。单轮命中率上限 = (base+g)/(base+2g)，base 为 system+tools、
+//     g 为每轮增量；base/g < 8 时前几轮天然到不了 90%。这是 prompt caching 的冷启动爬坡，
+//     真实 Anthropic 缓存同样如此，不是缺陷。真实 Claude Code 的 system + CLAUDE.md + tools
+//     通常 10-25k token，每轮增量 200-2000，base/g 约 10-50:1；这里取 ~3k token 的 system
+//     使 base/g ≈ 10，兼顾上述两个约束。
+//   - 每轮 assistant 带 text + 2 个 tool_use，user 回 2 个 tool_result，即大量小块。
+//     tool_use 只有 input 被计数、tool_result 只有 content 被计数，而 type/id/name 等
+//     结构字段一律计 0——块越多越碎，缺口越大，正是线上流量的形态。
+//   - cache_control 只打在 system 末块，模拟客户端最保守的断点策略；后续每个消息末尾的
+//     断点由 buildKiroCacheProfileFromBlocks 的传播逻辑补齐。
+func kiroClaudeCodeConversationBody(turns int) []byte {
+	system := strings.Repeat("You are a coding agent operating in a real repository. ", 220)
+	tools := `[{"name":"read_file","description":"Read a file from disk","input_schema":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}},{"name":"edit_file","description":"Apply an edit","input_schema":{"type":"object","properties":{"path":{"type":"string"},"patch":{"type":"string"}},"required":["path","patch"]}},{"name":"grep","description":"Search contents","input_schema":{"type":"object","properties":{"pattern":{"type":"string"}},"required":["pattern"]}}]`
+
+	messages := make([]string, 0, turns*2)
+	messages = append(messages, fmt.Sprintf(`{"role":"user","content":[{"type":"text","text":%q}]}`,
+		strings.Repeat("Please refactor the billing module carefully. ", 12)))
+	for turn := 1; turn <= turns; turn++ {
+		messages = append(messages, fmt.Sprintf(`{"role":"assistant","content":[{"type":"text","text":%q},{"type":"tool_use","id":"toolu_%d_a","name":"read_file","input":{"path":"internal/service/billing_%d.go"}},{"type":"tool_use","id":"toolu_%d_b","name":"grep","input":{"pattern":"CalculateCost_%d"}}]}`,
+			strings.Repeat("Inspecting the next call site. ", 6), turn, turn, turn, turn))
+		messages = append(messages, fmt.Sprintf(`{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_%d_a","content":[{"type":"text","text":%q}]},{"type":"tool_result","tool_use_id":"toolu_%d_b","content":[{"type":"text","text":%q}]}]}`,
+			turn, strings.Repeat("func CalculateCost(tokens UsageTokens) float64 { return 0 } ", 5),
+			turn, strings.Repeat("billing_service.go:120: CalculateCost invoked here ", 5)))
+	}
+
+	return []byte(fmt.Sprintf(`{"model":"claude-sonnet-4-6","system":[{"type":"text","text":%q,"cache_control":{"type":"ephemeral"}}],"tools":%s,"messages":[%s]}`,
+		system, tools, strings.Join(messages, ",")))
+}
+
+// Kiro 分组模拟缓存在多轮追加式会话下的稳态命中率必须 >= 90%。
+//
+// 命中率口径与前端面板一致（TokenUsageTrend.vue）：
+//
+//	cache_read / (input + cache_read + cache_creation)
+//
+// 而 prepareKiroCacheEmulationPlanFromProfile 令三者之和恒等于 inputTokens，故等价于
+// cache_read / inputTokens。这要求断点累计值与 inputTokens 处于同一 token 空间，即
+// profile.scaleBreakpointsToInputTokens 必须为 true——该标志缺失时，分子只统计正文、
+// 分母含整体 JSON 结构开销，命中率会被系统性压到 90% 以下。
+func TestKiroCacheEmulationSteadyStateHitRateMeetsTarget(t *testing.T) {
+	resetKiroCacheTracker()
+	svc := &GatewayService{}
+	account := kiroCacheAccount(4201, "refresh-steady", "access-steady")
+	group := kiroCacheGroup(1)
+
+	const totalTurns = 30
+	const minHitRate = 0.90
+
+	var aggregateRead, aggregateTotal int
+	for turn := 1; turn <= totalTurns; turn++ {
+		body := kiroClaudeCodeConversationBody(turn)
+		inputTokens := estimateKiroInputTokens(context.Background(), body)
+		usage := svc.buildKiroCacheEmulationUsage(context.Background(), account, group, body, "claude-sonnet-4-6", inputTokens)
+		require.NotNil(t, usage, "turn %d: cache emulation must produce usage", turn)
+
+		total := usage.InputTokens + usage.CacheReadInputTokens + usage.CacheCreationInputTokens
+		require.Equal(t, inputTokens, total, "turn %d: token buckets must sum to inputTokens", turn)
+
+		aggregateRead += usage.CacheReadInputTokens
+		aggregateTotal += total
+
+		hitRate := float64(usage.CacheReadInputTokens) / float64(total)
+		t.Logf("turn %2d: input=%6d read=%6d creation=%6d hit_rate=%.4f",
+			turn, usage.InputTokens, usage.CacheReadInputTokens, usage.CacheCreationInputTokens, hitRate)
+
+		if turn == 1 {
+			// 首轮无历史前缀，必然全量创建。
+			require.Zero(t, usage.CacheReadInputTokens, "turn 1 must be a cold miss")
+			continue
+		}
+		require.GreaterOrEqual(t, hitRate, minHitRate,
+			"turn %d: hit rate %.4f below target %.2f", turn, hitRate, minHitRate)
+	}
+
+	// 面板命中率是 token 加权聚合（见 TokenUsageTrend.vue），含首轮冷启动在内。
+	aggregateHitRate := float64(aggregateRead) / float64(aggregateTotal)
+	t.Logf("aggregate over %d turns: read=%d total=%d hit_rate=%.4f",
+		totalTurns, aggregateRead, aggregateTotal, aggregateHitRate)
+	require.GreaterOrEqual(t, aggregateHitRate, minHitRate,
+		"aggregate hit rate %.4f below target %.2f", aggregateHitRate, minHitRate)
 }


### PR DESCRIPTION
✨ feat(kiro_cache): 修正Anthropic路径缓存命中率计算偏差

在Claude Code等工具密集场景下,通过启用断点归一化使缓存
命中率从55-75%提升至90%以上

- 新增 TestKiroCacheEmulationSteadyStateHitRateMeetsTarget 测试用例,模拟30轮Claude Code长会话验证稳态命中率>=90%
- 新增 kiroClaudeCodeConversationBody 构造贴近真实场景的 Anthropic请求体,包含大量tool_use/tool_result小块
- 在 buildKiroAnthropicCacheProfile 中启用 scaleBreakpointsToInputTokens归一化标志
- 补充 kiroCacheProfile.scaleBreakpointsToInputTokens 字段 详细注释,说明断点累计值与totalInputTokens口径差异及归一化 必要性
- 修正工具块token计数从拍平值150改为真实序列化长度,避免 opus短请求被minCacheable误拒
- Anthropic路径在客户端未下发cache_control时兜底补断点, 防止该类流量污染命中率分母
- 重构 kiroCacheCredentialKey 使用 account.ID 作为命名空间 隔离键,确保对凭证轮转完全免疫
- 重命名 applyKiroResponsesDefaultBreakpoints 为 applyKiroDefaultBreakpoints 反映其通用性
- 补充凭证轮转免疫与跨账号隔离测试用例
- 移除未使用的 ExponentialBackoffWithJitter 函数
```