### PR TITLE
Optimize enterprise profile detection logic and skip invalid API calls

### DIFF
--- a/backend/internal/service/kiro_http_helpers.go
+++ b/backend/internal/service/kiro_http_helpers.go
@@ -41,6 +41,51 @@ func kiroDefaultProfileARN(account *Account) string {
 	return kiroBuilderIDProfileARN
 }
 
+// kiroAccountLacksEnterpriseProfile 判断账号是否不存在企业 profile。
+//
+// BuilderId（个人 Builder ID）与 Enterprise（企业自建 IAM Identity Center）的 auth_method
+// 都是 "idc"，无法据此区分，只能按 provider 判断。provider 取值受白名单约束
+// （Google/Github/BuilderId/Enterprise/ExternalIdp，见 kiropkg.IsValidKiroProvider），
+// 企业账号必为 kiropkg.ProviderEnterprise。
+//
+// 无企业 profile 的账号调用 ListAvailableProfiles 必然返回
+// 403 AccessDeniedException: "AWS Builder ID is not supported for this operation."，
+// 直接回填默认 ARN 即可，无需发起注定失败的请求。
+//
+// 判定为 allow-list：仅当存在企业身份证据（provider 为 Enterprise/ExternalIdp，
+// 或 start_url 指向自建 IAM Identity Center）时才返回 false 去查询；
+// 其余（BuilderId、Social、以及早期兜底写入 "AWS" 这类非白名单遗留值）一律返回 true 跳过。
+func kiroAccountLacksEnterpriseProfile(account *Account) bool {
+	if account == nil {
+		return false
+	}
+	// ExternalIdp（企业外部 IdP）可能持有真实 profile，需要查询。
+	provider := strings.TrimSpace(account.GetCredential("provider"))
+	authMethod := strings.TrimSpace(account.GetCredential("auth_method"))
+	if strings.EqualFold(provider, kiropkg.ProviderExternalIdp) || strings.EqualFold(authMethod, "external_idp") {
+		return false
+	}
+	// Enterprise：企业自建 IAM Identity Center，需要查询真实 profile ARN。
+	if strings.EqualFold(provider, kiropkg.ProviderEnterprise) {
+		return false
+	}
+	// 白名单内的 BuilderId/Google/Github 明确无企业 profile。provider 经白名单校验，
+	// 权威性高于 start_url，即便 start_url 看似自建也直接跳过。
+	if strings.EqualFold(provider, kiropkg.ProviderBuilderId) ||
+		strings.EqualFold(provider, kiropkg.ProviderGoogle) ||
+		strings.EqualFold(provider, kiropkg.ProviderGithub) ||
+		kiroIsSocialLogin(account) {
+		return true
+	}
+	// provider 为遗留非白名单值（早期兜底的 "AWS" 等）时，自建 start_url 仍是企业身份的有效证据。
+	// 容忍末尾斜杠差异，语义对齐 kiropkg.resolveIDCProvider。
+	startURL := strings.TrimRight(strings.TrimSpace(account.GetCredential("start_url")), "/")
+	if startURL != "" && !strings.EqualFold(startURL, strings.TrimRight(kiropkg.BuilderIDStartURL, "/")) {
+		return false
+	}
+	return true
+}
+
 func buildKiroAccountKey(account *Account) string {
 	if account == nil {
 		return ""

--- a/backend/internal/service/kiro_http_helpers_test.go
+++ b/backend/internal/service/kiro_http_helpers_test.go
@@ -464,3 +464,97 @@ func TestNormalizeKiroEndpointFieldsAuto(t *testing.T) {
 	normalizeKiroEndpointFields(g2)
 	require.Equal(t, "", g2.KiroEndpointMode)
 }
+
+// TestKiroAccountLacksEnterpriseProfile 验证 BuilderId/Social 被判定为无企业 profile（跳过
+// ListAvailableProfiles），而 Enterprise/ExternalIdp 及未知 provider 一律照旧查询。
+func TestKiroAccountLacksEnterpriseProfile(t *testing.T) {
+	cases := []struct {
+		name        string
+		credentials map[string]any
+		want        bool
+	}{
+		{
+			name:        "provider BuilderId 跳过",
+			credentials: map[string]any{"auth_method": "idc", "provider": "BuilderId"},
+			want:        true,
+		},
+		{
+			name:        "provider 大小写不敏感",
+			credentials: map[string]any{"auth_method": "idc", "provider": "builderid"},
+			want:        true,
+		},
+		{
+			name:        "social 登录跳过",
+			credentials: map[string]any{"auth_method": "social", "provider": "Github"},
+			want:        true,
+		},
+		{
+			name:        "builder id start_url 跳过",
+			credentials: map[string]any{"auth_method": "idc", "start_url": kiropkg.BuilderIDStartURL},
+			want:        true,
+		},
+		{
+			name:        "builder id start_url 末尾斜杠跳过",
+			credentials: map[string]any{"auth_method": "idc", "start_url": kiropkg.BuilderIDStartURL + "/"},
+			want:        true,
+		},
+		{
+			name:        "provider 与 start_url 均缺失视为 BuilderId",
+			credentials: map[string]any{"api_region": "us-west-2"},
+			want:        true,
+		},
+		{
+			name:        "provider Enterprise 照旧查询",
+			credentials: map[string]any{"auth_method": "idc", "provider": "Enterprise"},
+			want:        false,
+		},
+		{
+			name:        "provider Enterprise 大小写不敏感",
+			credentials: map[string]any{"auth_method": "idc", "provider": "enterprise"},
+			want:        false,
+		},
+		{
+			name:        "遗留 provider AWS + 企业 start_url 照旧查询",
+			credentials: map[string]any{"auth_method": "idc", "provider": "AWS", "start_url": "https://d-example.awsapps.com/start"},
+			want:        false,
+		},
+		{
+			name:        "遗留 provider AWS 无 start_url 跳过",
+			credentials: map[string]any{"auth_method": "idc", "provider": "AWS"},
+			want:        true,
+		},
+		{
+			name:        "遗留 provider AWS + builder id start_url 跳过",
+			credentials: map[string]any{"auth_method": "idc", "provider": "AWS", "start_url": kiropkg.BuilderIDStartURL},
+			want:        true,
+		},
+		{
+			name:        "企业 start_url 无 provider 照旧查询",
+			credentials: map[string]any{"auth_method": "idc", "start_url": "https://d-example.awsapps.com/start"},
+			want:        false,
+		},
+		{
+			name:        "external_idp 照旧查询",
+			credentials: map[string]any{"auth_method": "external_idp", "provider": "ExternalIdp"},
+			want:        false,
+		},
+		{
+			name:        "auth_method external_idp 无 provider 照旧查询",
+			credentials: map[string]any{"auth_method": "external_idp"},
+			want:        false,
+		},
+		{
+			name:        "provider BuilderId 优先于企业 start_url 跳过",
+			credentials: map[string]any{"auth_method": "idc", "provider": "BuilderId", "start_url": "https://d-example.awsapps.com/start"},
+			want:        true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			account := &Account{Platform: PlatformKiro, Type: AccountTypeOAuth, Credentials: tc.credentials}
+			require.Equal(t, tc.want, kiroAccountLacksEnterpriseProfile(account))
+		})
+	}
+
+	require.False(t, kiroAccountLacksEnterpriseProfile(nil))
+}

--- a/backend/internal/service/kiro_mapping_fallback_test.go
+++ b/backend/internal/service/kiro_mapping_fallback_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/stretchr/testify/require"
@@ -69,7 +70,7 @@ func TestGatewayServiceCalculateTokenCost_KiroAutoUsesConservativeFallback(t *te
 	}, 1.1)
 	require.NoError(t, err)
 
-	cost := svc.calculateTokenCost(context.Background(), result, &APIKey{}, "auto", 1.1, &recordUsageOpts{IsKiroAccount: true})
+	cost := svc.calculateTokenCost(context.Background(), result, &APIKey{}, "auto", 1.1, time.Time{}, &recordUsageOpts{IsKiroAccount: true})
 	require.NotNil(t, cost)
 	require.InDelta(t, expected.ActualCost, cost.ActualCost, 1e-12)
 	require.InDelta(t, expected.TotalCost, cost.TotalCost, 1e-12)

--- a/backend/internal/service/kiro_profile_resolver.go
+++ b/backend/internal/service/kiro_profile_resolver.go
@@ -116,8 +116,10 @@ func kiroListAvailableProfiles(ctx context.Context, account *Account, token stri
 //
 // 行为：
 //   - API Key 凭据 / 已有真实（非占位符）profileArn → 直接返回，不发起网络请求
+//   - BuilderId / Social 账号（确定无企业 profile）→ 直接回填默认 ARN，跳过 ListAvailableProfiles
+//     （该 API 对 Builder ID 身份必然返回 403，见 kiroAccountLacksEnterpriseProfile）
 //   - 否则调用 ListAvailableProfiles，命中真实 ARN 时写回凭据并持久化到 DB
-//   - 上游无 profile（如 Social/BuilderID 账号）→ 回填默认 ARN（Social → Social ARN，其余 → BuilderID 占位符）并持久化
+//   - 上游无 profile → 回填默认 ARN（Social → Social ARN，其余 → BuilderID 占位符）并持久化
 //   - 进程内去重：同一账号仅首次请求时触发 API 调用，避免重复查询
 func kiroResolveAndPersistProfileArn(ctx context.Context, repo AccountRepository, account *Account, token string) string {
 	if account == nil {
@@ -151,9 +153,15 @@ func kiroResolveAndPersistProfileArn(ctx context.Context, repo AccountRepository
 	once.Do(func() {
 		arn := kiroDefaultProfileARN(account)
 
-		profiles, err := kiroListAvailableProfiles(ctx, account, token)
-		if err != nil {
-			// API 失败（如 BuilderID 账号不支持 ListAvailableProfiles），fallback 到默认 ARN
+		if kiroAccountLacksEnterpriseProfile(account) {
+			// BuilderId / Social 身份没有企业 profile，ListAvailableProfiles 必然 403，
+			// 直接使用默认 ARN，省掉一次注定失败的请求。
+			logger.L().Debug("kiro profileArn resolution skipped for non-enterprise login, using default",
+				zap.Int64("account_id", accountID),
+				zap.String("profile_arn", arn),
+			)
+		} else if profiles, err := kiroListAvailableProfiles(ctx, account, token); err != nil {
+			// API 失败（如凭据被判定为不支持该操作的身份），fallback 到默认 ARN
 			logger.L().Warn("kiro profileArn resolution failed, using default",
 				zap.Int64("account_id", accountID),
 				zap.String("profile_arn", arn),

--- a/backend/internal/service/openai_gateway_record_usage_test.go
+++ b/backend/internal/service/openai_gateway_record_usage_test.go
@@ -2806,6 +2806,7 @@ func TestGatewayServiceCalculateRecordUsageCost_KiroGPT56UsesOpenAIFallbackInste
 		"gpt-5.6-terra",
 		1.0,
 		1.0,
+		time.Time{},
 		&recordUsageOpts{IsKiroAccount: true},
 	)
 


### PR DESCRIPTION
test(kiro): 优化企业profile检测逻辑并跳过无效API调用

- 新增kiroAccountLacksEnterpriseProfile判断账号是否缺失企业profile
- BuilderId/Social账号直接使用默认ARN，跳过ListAvailableProfiles
- Enterprise/ExternalIdp及自建start_url账号保持原有查询逻辑
- provider白名单优先级高于start_url，容忍末尾斜杠差异
- 添加11个测试用例覆盖各类身份组合与遗留provider兼容性
- 修复测试文件缺失time.Time{}参数导致的编译错误
```