### PR TITLE
fix(kiro): 修复 Builder ID / IDC 用量、模型列表和测活 403

### DIFF
--- a/backend/internal/pkg/kiro/fingerprint.go
+++ b/backend/internal/pkg/kiro/fingerprint.go
@@ -45,7 +45,7 @@ var (
 	}
 	nodeVersions = []string{"22.22.0"}
 	kiroVersions = []string{
-		"0.11.132", "0.11.131", "0.11.130",
+		"0.12.155",
 	}
 )
 
@@ -215,7 +215,7 @@ func BuildRuntimeUserAgent(accountKey, machineID string) string {
 	return fmt.Sprintf(
 		"aws-sdk-js/%s ua/2.1 os/%s#%s lang/js md/nodejs#%s api/codewhispererstreaming#%s m/E KiroIDE-%s-%s",
 		fp.StreamingSDKVersion,
-		fp.OSType,
+		usageUAOSType(fp.OSType),
 		fp.OSVersion,
 		fp.NodeVersion,
 		fp.StreamingSDKVersion,
@@ -232,6 +232,47 @@ func BuildRuntimeAmzUserAgent(accountKey, machineID string) string {
 		fp.KiroVersion,
 		fp.KiroHash,
 	)
+}
+
+// 用量 REST GET 的客户端版本。服务端会按 UA 做 Builder ID / IdC 准入：
+// KiroIDE-0.6.x / 0.9.x 会 403 "User is not authorized to make this call"；
+// 对齐 kiro-manager-lite v1.0.17 实测通过的 0.12.155 + aws-sdk-js/1.0.34。
+const (
+	UsageAPIKiroVersion = "0.12.155"
+	usageAPISDKVersion  = "1.0.34"
+)
+
+func BuildUsageRuntimeUserAgent(accountKey, machineID string) string {
+	fp := globalRuntimeFingerprints().Get(accountKey, machineID)
+	return fmt.Sprintf(
+		"aws-sdk-js/%s ua/2.1 os/%s#%s lang/js md/nodejs#%s api/codewhispererstreaming#%s m/E KiroIDE-%s-%s",
+		usageAPISDKVersion,
+		usageUAOSType(fp.OSType),
+		fp.OSVersion,
+		fp.NodeVersion,
+		usageAPISDKVersion,
+		UsageAPIKiroVersion,
+		fp.KiroHash,
+	)
+}
+
+func BuildUsageRuntimeAmzUserAgent(accountKey, machineID string) string {
+	fp := globalRuntimeFingerprints().Get(accountKey, machineID)
+	return fmt.Sprintf("aws-sdk-js/%s KiroIDE-%s-%s", usageAPISDKVersion, UsageAPIKiroVersion, fp.KiroHash)
+}
+
+func usageUAOSType(osType string) string {
+	switch strings.TrimSpace(osType) {
+	case "darwin":
+		return "macos"
+	case "windows":
+		return "win32"
+	default:
+		if osType == "" {
+			return "macos"
+		}
+		return osType
+	}
 }
 
 func BuildOIDCHeaders(accountKey, machineID string) map[string]string {

--- a/backend/internal/pkg/kiro/fingerprint_test.go
+++ b/backend/internal/pkg/kiro/fingerprint_test.go
@@ -10,6 +10,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBuildUsageRuntimeUserAgentUsesCurrentAdmittedClient(t *testing.T) {
+	key := BuildAccountKey("client-id", "", "", "", 1)
+	machineID := BuildMachineID("refresh-token", "", "")
+
+	ua := BuildUsageRuntimeUserAgent(key, machineID)
+	amzUA := BuildUsageRuntimeAmzUserAgent(key, machineID)
+
+	require.Contains(t, ua, "api/codewhispererstreaming#1.0.34")
+	require.Contains(t, ua, "aws-sdk-js/1.0.34")
+	require.Contains(t, ua, "KiroIDE-"+UsageAPIKiroVersion+"-")
+	require.Contains(t, ua, machineID)
+	require.Contains(t, amzUA, "aws-sdk-js/1.0.34")
+	require.Contains(t, amzUA, "KiroIDE-"+UsageAPIKiroVersion+"-")
+	require.NotContains(t, ua, "api/codewhispererruntime")
+	require.Contains(t, BuildRuntimeUserAgent(key, machineID), "KiroIDE-"+UsageAPIKiroVersion+"-")
+}
+
 func TestBuildLoginHeadersStable(t *testing.T) {
 	headers1 := BuildLoginHeaders("", "")
 	headers2 := BuildLoginHeaders("", "")
@@ -30,7 +47,7 @@ func TestBuildLoginHeadersUsesProvidedMachineID(t *testing.T) {
 
 	require.Equal(t, headers1["User-Agent"], headers2["User-Agent"])
 	require.NotEqual(t, headers1["User-Agent"], headers3["User-Agent"])
-	require.Contains(t, headers1["User-Agent"], "KiroIDE-0.11.")
+	require.Contains(t, headers1["User-Agent"], "KiroIDE-0.12.")
 	require.Contains(t, headers1["User-Agent"], machineIDA)
 }
 

--- a/backend/internal/pkg/kiro/translator_test.go
+++ b/backend/internal/pkg/kiro/translator_test.go
@@ -27,7 +27,7 @@ func TestBuildRuntimeUserAgentStable(t *testing.T) {
 	require.Equal(t, ua1, ua2)
 	require.Contains(t, ua1, "KiroIDE-")
 	require.Contains(t, amzUA, "KiroIDE-")
-	require.Contains(t, ua1, "KiroIDE-0.11.")
+	require.Contains(t, ua1, "KiroIDE-0.12.155")
 	require.Contains(t, ua1, "aws-sdk-js/1.0.34")
 	require.Contains(t, ua1, "md/nodejs#22.22.0")
 	require.Contains(t, ua1, machineID)

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -624,8 +624,8 @@ func formatKiroTestError(statusCode int, body []byte, requestedModel string, acc
 func (s *AccountTestService) executeKiroTestUpstream(ctx context.Context, account *Account, anthropicBody []byte, mappedModel, token string) (*http.Response, error) {
 	modelID := kiropkg.MapModel(mappedModel)
 	currentToken := token
-	// 测试连接走 Q endpoint，Q endpoint 不需要 profileArn（凭据中的占位符 ARN 会导致 403）
-	profileArn := ""
+	ensureKiroEnterpriseRealProfileArn(ctx, s.accountRepo, account, currentToken)
+	profileArn := kiroOAuthRequestProfileArn(account)
 	preparedBody := prepareKiroPayloadBodyForRequestModel(anthropicBody, mappedModel)
 	buildResult, err := kiropkg.BuildKiroPayloadWithContext(preparedBody, modelID, profileArn, "AI_EDITOR", nil)
 	if err != nil {

--- a/backend/internal/service/account_test_service_kiro_test.go
+++ b/backend/internal/service/account_test_service_kiro_test.go
@@ -207,8 +207,7 @@ func TestAccountTestService_KiroInvalidModelDoesNotRefreshProfileArnOrRetry(t *t
 
 	firstBody, readErr := io.ReadAll(upstream.requests[0].Body)
 	require.NoError(t, readErr)
-	// Q endpoint 不传 profileArn（凭据中的占位符 ARN 会导致 403）
-	require.NotContains(t, string(firstBody), `"profileArn"`)
+	require.Contains(t, string(firstBody), `"profileArn":"arn:aws:codewhisperer:us-east-1:123456789012:profile/STALE"`)
 	require.Equal(t, "arn:aws:codewhisperer:us-east-1:123456789012:profile/STALE", account.GetCredential("profile_arn"))
 }
 
@@ -271,7 +270,7 @@ func TestBuildKiroPayloadForAccount_KiroBuilderIDWithoutProfileArnOmitsProfileAr
 	buildResult, err := (&GatewayService{}).buildKiroPayloadForAccount(context.Background(), account, nil, payloadBytes, "claude-sonnet-4-6", "kiro-access-token", "claude-sonnet-4-6", nil)
 	require.NoError(t, err)
 	kiroPayload := buildResult.Payload
-	require.NotContains(t, string(kiroPayload), `"profileArn":`)
+	require.Contains(t, string(kiroPayload), `"profileArn":"`+kiroBuilderIDProfileARN+`"`)
 }
 
 func TestBuildKiroPayloadForAccount_KiroBuilderIDWithCachedProfileArnOmitsForQMode(t *testing.T) {
@@ -297,8 +296,7 @@ func TestBuildKiroPayloadForAccount_KiroBuilderIDWithCachedProfileArnOmitsForQMo
 	buildResult, err := (&GatewayService{}).buildKiroPayloadForAccount(context.Background(), account, nil, payloadBytes, "claude-sonnet-4-6", "kiro-access-token", "claude-sonnet-4-6", nil)
 	require.NoError(t, err)
 	kiroPayload := buildResult.Payload
-	// parsed=nil → Q endpoint 模式，Q endpoint 不传 profileArn
-	require.NotContains(t, string(kiroPayload), `"profileArn"`)
+	require.Contains(t, string(kiroPayload), `"profileArn":"arn:aws:codewhisperer:us-east-1:123456789012:profile/CACHED"`)
 }
 
 func TestGatewayServiceForwardRoutesKiroOAuthAndCapturesMeteringCredits(t *testing.T) {

--- a/backend/internal/service/kiro_alignment_test.go
+++ b/backend/internal/service/kiro_alignment_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -80,8 +79,13 @@ func kiroUsageTestBody(current float64) string {
 func setKiroUsageTestEndpoint(t *testing.T, endpoint string) {
 	t.Helper()
 	prevResolver := resolveKiroRuntimeEndpoint
+	prevSkip := kiroUsageSkipEnterpriseProfileResolve
 	resolveKiroRuntimeEndpoint = func(_ string) string { return endpoint }
-	t.Cleanup(func() { resolveKiroRuntimeEndpoint = prevResolver })
+	kiroUsageSkipEnterpriseProfileResolve = true
+	t.Cleanup(func() {
+		resolveKiroRuntimeEndpoint = prevResolver
+		kiroUsageSkipEnterpriseProfileResolve = prevSkip
+	})
 }
 
 func TestChannel_IsWebSearchEmulationEnabled_Kiro(t *testing.T) {
@@ -140,6 +144,61 @@ func TestOpenAIGatewayServiceRecordUsage_NormalizesKiroBillingModel(t *testing.T
 	require.InDelta(t, expectedCost.TotalCost, usageRepo.lastLog.TotalCost, 1e-12)
 }
 
+func requireKiroUsageLimitsQuery(t *testing.T, r *http.Request, profileArn string) {
+	t.Helper()
+	require.Equal(t, http.MethodGet, r.Method)
+	require.Equal(t, "/getUsageLimits", r.URL.Path)
+	require.Equal(t, kiroUsageOrigin, r.URL.Query().Get("origin"))
+	require.Equal(t, kiroUsageResourceType, r.URL.Query().Get("resourceType"))
+	require.Equal(t, kiroUsageIsEmailRequired, r.URL.Query().Get("isEmailRequired"))
+	require.Equal(t, profileArn, r.URL.Query().Get("profileArn"))
+	require.Contains(t, r.Header.Get("User-Agent"), "api/codewhispererstreaming#1.0.34")
+	require.Contains(t, r.Header.Get("User-Agent"), "KiroIDE-0.12.155-")
+	require.Contains(t, r.Header.Get("X-Amz-User-Agent"), "KiroIDE-0.12.155-")
+}
+
+func TestKiroUsageQueryProfileArn(t *testing.T) {
+	require.Equal(t, kiroSocialProfileARN, kiroUsageQueryProfileArn(&Account{
+		Credentials: map[string]any{"auth_method": "social", "provider": "Github"},
+	}))
+	require.Equal(t, "arn:aws:codewhisperer:us-east-1:123456789012:profile/REAL", kiroUsageQueryProfileArn(&Account{
+		Credentials: map[string]any{
+			"auth_method": "idc",
+			"provider":    "Enterprise",
+			"profile_arn": "arn:aws:codewhisperer:us-east-1:123456789012:profile/REAL",
+		},
+	}))
+	require.Equal(t, kiroBuilderIDProfileARN, kiroUsageQueryProfileArn(&Account{
+		Credentials: map[string]any{"auth_method": "idc", "provider": "BuilderId"},
+	}))
+	require.Equal(t, kiroBuilderIDProfileARN, kiroUsageQueryProfileArn(&Account{
+		Credentials: map[string]any{
+			"auth_method": "idc",
+			"provider":    "BuilderId",
+			"profile_arn": kiroBuilderIDProfileARN,
+		},
+	}))
+	require.Empty(t, kiroUsageQueryProfileArn(&Account{
+		Credentials: map[string]any{
+			"auth_method": "idc",
+			"provider":    "Enterprise",
+			"start_url":   "https://d-example.awsapps.com/start",
+		},
+	}))
+}
+
+func TestKiroUsageRegionCandidates(t *testing.T) {
+	require.Equal(t, []string{"us-east-1", "eu-central-1"}, kiroUsageRegionCandidates(&Account{
+		Credentials: map[string]any{"provider": "BuilderId"},
+	}))
+	require.Equal(t, []string{"eu-central-1", "us-east-1"}, kiroUsageRegionCandidates(&Account{
+		Credentials: map[string]any{"api_region": "eu-west-1"},
+	}))
+	require.Equal(t, []string{"us-east-1", "eu-central-1"}, kiroUsageRegionCandidates(&Account{
+		Credentials: map[string]any{"region": "ap-northeast-2"},
+	}))
+}
+
 func TestAccountUsageService_GetUsage_KiroMapsCredits(t *testing.T) {
 	account := Account{
 		ID:       701,
@@ -159,14 +218,9 @@ func TestAccountUsageService_GetUsage_KiroMapsCredits(t *testing.T) {
 	bonusExpiry := time.Now().Add(7 * 24 * time.Hour).Unix()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/getUsageLimits", r.URL.Path)
-		require.Equal(t, "arn:aws:codewhisperer:us-east-1:123456789012:profile/SOCIAL", r.URL.Query().Get("profileArn"))
-		require.Equal(t, kiroUsageOrigin, r.URL.Query().Get("origin"))
-		require.Equal(t, kiroUsageResourceType, r.URL.Query().Get("resourceType"))
+		requireKiroUsageLimitsQuery(t, r, "arn:aws:codewhisperer:us-east-1:123456789012:profile/SOCIAL")
 		require.Equal(t, "Bearer kiro-access-token", r.Header.Get("Authorization"))
 		require.Equal(t, "*/*", r.Header.Get("Accept"))
-		require.True(t, strings.Contains(r.Header.Get("User-Agent"), "KiroIDE-"))
-		require.True(t, strings.Contains(r.Header.Get("X-Amz-User-Agent"), "KiroIDE-"))
 		require.Equal(t, "vibe", r.Header.Get("x-amzn-kiro-agent-mode"))
 		require.Equal(t, "true", r.Header.Get("x-amzn-codewhisperer-optout"))
 		require.NotEmpty(t, r.Header.Get("Amz-Sdk-Invocation-Id"))
@@ -229,6 +283,7 @@ func TestAccountUsageService_GetUsage_KiroUsesTokenProviderAccessToken(t *testin
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "Bearer provider-access-token", r.Header.Get("Authorization"))
+		requireKiroUsageLimitsQuery(t, r, kiroSocialProfileARN)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(kiroUsageTestBody(15)))
 	}))
@@ -423,7 +478,7 @@ func TestAccountUsageService_GetUsage_KiroActiveUsesCachedSnapshotWithinTTL(t *t
 	require.Empty(t, usage.ErrorCode)
 }
 
-func TestAccountUsageService_GetUsage_KiroBuilderIDWithoutProfileArnOmitsProfileArn(t *testing.T) {
+func TestAccountUsageService_GetUsage_KiroBuilderIDSendsPlaceholderProfileArn(t *testing.T) {
 	account := Account{
 		ID:       703,
 		Platform: PlatformKiro,
@@ -433,14 +488,14 @@ func TestAccountUsageService_GetUsage_KiroBuilderIDWithoutProfileArnOmitsProfile
 			"provider":     "BuilderId",
 			"auth_method":  "idc",
 			"region":       "us-east-1",
+			"start_url":    "https://view.awsapps.com/start",
 		},
 	}
 	repo := &stubOpenAIAccountRepo{accounts: []Account{account}}
 	svc := NewAccountUsageService(repo, nil, nil, nil, nil, nil, nil, nil, NewUsageCache(), nil, nil)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/getUsageLimits", r.URL.Path)
-		require.Empty(t, r.URL.Query().Get("profileArn"))
+		requireKiroUsageLimitsQuery(t, r, kiroBuilderIDProfileARN)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"subscriptionInfo": {"subscriptionTitle":"KIRO PRO+"},
@@ -453,10 +508,7 @@ func TestAccountUsageService_GetUsage_KiroBuilderIDWithoutProfileArnOmitsProfile
 		}`))
 	}))
 	defer server.Close()
-
-	prevResolver := resolveKiroRuntimeEndpoint
-	resolveKiroRuntimeEndpoint = func(_ string) string { return server.URL }
-	defer func() { resolveKiroRuntimeEndpoint = prevResolver }()
+	setKiroUsageTestEndpoint(t, server.URL)
 
 	usage, err := svc.GetUsage(context.Background(), account.ID)
 	require.NoError(t, err)
@@ -485,8 +537,7 @@ func TestAccountUsageService_GetUsage_KiroEnterpriseUsesCredentialProfileArn(t *
 	const resolvedProfileArn = "arn:aws:codewhisperer:us-east-1:123456789012:profile/REALENTERPRISE"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/getUsageLimits", r.URL.Path)
-		require.Equal(t, resolvedProfileArn, r.URL.Query().Get("profileArn"))
+		requireKiroUsageLimitsQuery(t, r, resolvedProfileArn)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"subscriptionInfo": {"subscriptionTitle":"KIRO PRO+"},
@@ -532,8 +583,7 @@ func TestAccountUsageService_GetUsage_KiroUsesAPIRegionForUsageRequest(t *testin
 	const resolvedProfileArn = "arn:aws:codewhisperer:eu-west-1:123456789012:profile/REALAPIREGION"
 	gotRegions := make([]string, 0, 2)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/getUsageLimits", r.URL.Path)
-		require.Equal(t, resolvedProfileArn, r.URL.Query().Get("profileArn"))
+		requireKiroUsageLimitsQuery(t, r, resolvedProfileArn)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"subscriptionInfo": {"subscriptionTitle":"KIRO PRO+"},
@@ -557,10 +607,10 @@ func TestAccountUsageService_GetUsage_KiroUsesAPIRegionForUsageRequest(t *testin
 	usage, err := svc.GetUsage(context.Background(), account.ID)
 	require.NoError(t, err)
 	require.NotNil(t, usage)
-	require.Equal(t, []string{"eu-west-1"}, gotRegions)
+	require.Equal(t, []string{kiroUsagePrimaryEURegion}, gotRegions)
 }
 
-func TestAccountUsageService_GetUsage_KiroOmitsProfileArnAndUsesDefaultRegionWithoutAPIRegionOrProfileArn(t *testing.T) {
+func TestAccountUsageService_GetUsage_KiroIDCWithoutProfileArnUsesPlaceholderAndDefaultRegion(t *testing.T) {
 	account := Account{
 		ID:       710,
 		Platform: PlatformKiro,
@@ -578,8 +628,7 @@ func TestAccountUsageService_GetUsage_KiroOmitsProfileArnAndUsesDefaultRegionWit
 
 	gotRegions := make([]string, 0, 2)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/getUsageLimits", r.URL.Path)
-		require.Empty(t, r.URL.Query().Get("profileArn"))
+		requireKiroUsageLimitsQuery(t, r, "")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"subscriptionInfo": {"subscriptionTitle":"KIRO PRO+"},
@@ -593,6 +642,10 @@ func TestAccountUsageService_GetUsage_KiroOmitsProfileArnAndUsesDefaultRegionWit
 	}))
 	defer server.Close()
 
+	prevSkip := kiroUsageSkipEnterpriseProfileResolve
+	kiroUsageSkipEnterpriseProfileResolve = true
+	defer func() { kiroUsageSkipEnterpriseProfileResolve = prevSkip }()
+
 	prevResolver := resolveKiroRuntimeEndpoint
 	resolveKiroRuntimeEndpoint = func(region string) string {
 		gotRegions = append(gotRegions, region)
@@ -604,6 +657,58 @@ func TestAccountUsageService_GetUsage_KiroOmitsProfileArnAndUsesDefaultRegionWit
 	require.NoError(t, err)
 	require.NotNil(t, usage)
 	require.Equal(t, []string{kiroDefaultRegion}, gotRegions)
+}
+
+func TestAccountUsageService_GetUsage_KiroFallsBackToAlternateUsageRegionOn403(t *testing.T) {
+	account := Account{
+		ID:       713,
+		Platform: PlatformKiro,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token": "kiro-access-token",
+			"provider":     "Enterprise",
+			"auth_method":  "idc",
+			"start_url":    "https://d-example.awsapps.com/start",
+		},
+	}
+	repo := &stubOpenAIAccountRepo{accounts: []Account{account}}
+	svc := NewAccountUsageService(repo, nil, nil, nil, nil, nil, nil, nil, NewUsageCache(), nil, nil)
+
+	primaryHits := 0
+	fallbackHits := 0
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		primaryHits++
+		requireKiroUsageLimitsQuery(t, r, "")
+		http.Error(w, `{"message":"Invalid token"}`, http.StatusForbidden)
+	}))
+	defer primary.Close()
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackHits++
+		requireKiroUsageLimitsQuery(t, r, "")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(kiroUsageTestBody(19)))
+	}))
+	defer fallback.Close()
+
+	prevSkip := kiroUsageSkipEnterpriseProfileResolve
+	kiroUsageSkipEnterpriseProfileResolve = true
+	prevResolver := resolveKiroRuntimeEndpoint
+	resolveKiroRuntimeEndpoint = func(region string) string {
+		if region == kiroUsagePrimaryEURegion {
+			return fallback.URL
+		}
+		return primary.URL
+	}
+	t.Cleanup(func() {
+		resolveKiroRuntimeEndpoint = prevResolver
+		kiroUsageSkipEnterpriseProfileResolve = prevSkip
+	})
+
+	usage, err := svc.GetUsage(context.Background(), account.ID)
+	require.NoError(t, err)
+	require.Equal(t, 19.0, usage.KiroCredit.CurrentUsage)
+	require.Equal(t, 1, primaryHits)
+	require.Equal(t, 1, fallbackHits)
 }
 
 func TestAccountUsageService_GetUsage_KiroIncludesRuntimeCooldownState(t *testing.T) {

--- a/backend/internal/service/kiro_http_helpers.go
+++ b/backend/internal/service/kiro_http_helpers.go
@@ -228,6 +228,16 @@ func resolveKiroPayloadProfileArn(account *Account) string {
 	return strings.TrimSpace(account.GetCredential("profile_arn"))
 }
 
+// kiroOAuthRequestProfileArn 返回 Q 端点（用量 / 模型列表 / 对话）必须带的 profileArn。
+// API Key（ksk_）不能带 profileArn。OAuth：Social 用固定 ARN，Builder ID 用占位符，
+// Enterprise 必须是 ListAvailableProfiles 得到的真实 ARN。
+func kiroOAuthRequestProfileArn(account *Account) string {
+	if account == nil || account.Type == AccountTypeAPIKey {
+		return ""
+	}
+	return kiroUsageQueryProfileArn(account)
+}
+
 // kiroResolveProfileArnForKRS 返回 KRS endpoint 所需的 profileArn。
 // KRS endpoint（runtime.us-east-1.kiro.dev）强制要求 profileArn，
 // 凭据无值时 fallback 到默认 ARN（Social → Social ARN，其余 → BuilderID 占位符）。
@@ -263,9 +273,11 @@ func newKiroJSONRequest(ctx context.Context, endpointURL string, payload []byte,
 		req.Header.Set("X-Amz-Target", amzTarget)
 	}
 	if account != nil {
-		profileArn := resolveKiroPayloadProfileArn(account)
-		if profileArn == "" && endpointURL == kiroKRSEndpointURL {
+		var profileArn string
+		if endpointURL == kiroKRSEndpointURL {
 			profileArn = kiroResolveProfileArnForKRS(account)
+		} else {
+			profileArn = kiroOAuthRequestProfileArn(account)
 		}
 		if profileArn != "" {
 			req.Header.Set("x-amzn-kiro-profile-arn", profileArn)

--- a/backend/internal/service/kiro_models.go
+++ b/backend/internal/service/kiro_models.go
@@ -1,0 +1,190 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/httpclient"
+	kiropkg "github.com/Wei-Shaw/sub2api/internal/pkg/kiro"
+	"github.com/google/uuid"
+)
+
+type kiroAvailableModel struct {
+	ModelID   string `json:"modelId"`
+	ModelName string `json:"modelName"`
+}
+
+type kiroAvailableModelsResponse struct {
+	DefaultModel *kiroAvailableModel  `json:"defaultModel"`
+	Models       []kiroAvailableModel `json:"models"`
+	NextToken    string               `json:"nextToken"`
+}
+
+func (s *AccountTestService) fetchKiroUpstreamModels(ctx context.Context, account *Account) ([]string, error) {
+	if account == nil {
+		return nil, newUpstreamModelSyncConfigError("Account is required", nil)
+	}
+	token, err := s.kiroModelsAccessToken(ctx, account)
+	if err != nil {
+		return nil, err
+	}
+	ensureKiroEnterpriseRealProfileArn(ctx, s.accountRepo, account, token)
+	profileArn := kiroOAuthRequestProfileArn(account)
+
+	candidates := kiroUsageRegionCandidates(account)
+	var lastErr error
+	seen := make(map[string]struct{}, len(candidates))
+	for i, region := range candidates {
+		endpoint := strings.TrimRight(resolveKiroRuntimeEndpoint(region), "/")
+		if endpoint == "" {
+			continue
+		}
+		if _, dup := seen[endpoint]; dup {
+			continue
+		}
+		seen[endpoint] = struct{}{}
+
+		models, err := s.doKiroListAvailableModels(ctx, account, endpoint, token, profileArn)
+		if err == nil {
+			if len(models) == 0 {
+				return nil, newUpstreamModelSyncUpstreamError("Upstream returned no supported models", nil)
+			}
+			return models, nil
+		}
+		lastErr = err
+		var httpErr *kiroUsageHTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusForbidden && i+1 < len(candidates) {
+			continue
+		}
+		break
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("kiro list models request failed: no endpoint")
+	}
+	return nil, newUpstreamModelSyncUpstreamError("Failed to request upstream model list", lastErr)
+}
+
+func (s *AccountTestService) kiroModelsAccessToken(ctx context.Context, account *Account) (string, error) {
+	if account.Type == AccountTypeAPIKey {
+		token := firstKiroCredential(account, "kiro_api_key", "kiroApiKey", "api_key")
+		if token == "" {
+			return "", newUpstreamModelSyncConfigError("No API key available", nil)
+		}
+		return token, nil
+	}
+	if s == nil || s.kiroTokenProvider == nil {
+		token := strings.TrimSpace(account.GetCredential("access_token"))
+		if token == "" {
+			return "", newUpstreamModelSyncConfigError("Kiro token provider not configured", nil)
+		}
+		return token, nil
+	}
+	token, err := s.kiroTokenProvider.GetAccessToken(ctx, account)
+	if err != nil {
+		return "", newUpstreamModelSyncUpstreamError("Failed to get Kiro access token", err)
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return "", newUpstreamModelSyncConfigError("No access token available", nil)
+	}
+	return token, nil
+}
+
+func (s *AccountTestService) doKiroListAvailableModels(ctx context.Context, account *Account, endpoint, token, profileArn string) ([]string, error) {
+	reqURL, err := url.Parse(endpoint + "/ListAvailableModels")
+	if err != nil {
+		return nil, fmt.Errorf("build kiro models url failed: %w", err)
+	}
+	q := reqURL.Query()
+	q.Set("origin", kiroUsageOrigin)
+	q.Set("maxResults", "50")
+	if profileArn = strings.TrimSpace(profileArn); profileArn != "" {
+		q.Set("profileArn", profileArn)
+	}
+	reqURL.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create kiro models request failed: %w", err)
+	}
+	accountKey := buildKiroAccountKey(account)
+	machineID := buildKiroMachineID(account)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(token))
+	req.Header.Set("User-Agent", kiropkg.BuildUsageRuntimeUserAgent(accountKey, machineID))
+	req.Header.Set("X-Amz-User-Agent", kiropkg.BuildUsageRuntimeAmzUserAgent(accountKey, machineID))
+	req.Header.Set("x-amzn-kiro-agent-mode", "vibe")
+	req.Header.Set("Amz-Sdk-Request", "attempt=1; max=1")
+	req.Header.Set("Amz-Sdk-Invocation-Id", uuid.NewString())
+	applyKiroConditionalHeaders(req, account)
+
+	client, err := httpclient.GetClient(httpclient.Options{
+		ProxyURL:           kiroProxyURL(account),
+		Timeout:            30 * time.Second,
+		ValidateResolvedIP: true,
+		AllowPrivateHosts:  isLoopbackEndpoint(endpoint),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create kiro models client failed: %w", err)
+	}
+
+	models := make([]string, 0, 16)
+	seen := make(map[string]struct{}, 16)
+	add := func(id string) {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return
+		}
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		models = append(models, id)
+	}
+
+	for page := 0; page < 8; page++ {
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("kiro list models request failed: %w", err)
+		}
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("read kiro models response failed: %w", readErr)
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, &kiroUsageHTTPError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(body))}
+		}
+		var parsed kiroAvailableModelsResponse
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			return nil, fmt.Errorf("decode kiro models response failed: %w", err)
+		}
+		if parsed.DefaultModel != nil {
+			add(parsed.DefaultModel.ModelID)
+		}
+		for _, model := range parsed.Models {
+			add(model.ModelID)
+		}
+		next := strings.TrimSpace(parsed.NextToken)
+		if next == "" {
+			break
+		}
+		q := req.URL.Query()
+		q.Set("nextToken", next)
+		req.URL.RawQuery = q.Encode()
+		nextReq, err := http.NewRequestWithContext(ctx, http.MethodGet, req.URL.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+		nextReq.Header = req.Header.Clone()
+		req = nextReq
+	}
+	return models, nil
+}

--- a/backend/internal/service/kiro_models_test.go
+++ b/backend/internal/service/kiro_models_test.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchKiroUpstreamModelsSendsProfileArnAndParsesIDs(t *testing.T) {
+	account := &Account{
+		ID:       801,
+		Platform: PlatformKiro,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token": "kiro-access-token",
+			"auth_method":  "idc",
+			"provider":     "BuilderId",
+			"region":       "us-east-1",
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/ListAvailableModels", r.URL.Path)
+		require.Equal(t, "AI_EDITOR", r.URL.Query().Get("origin"))
+		require.Equal(t, kiroBuilderIDProfileARN, r.URL.Query().Get("profileArn"))
+		require.Contains(t, r.Header.Get("User-Agent"), "KiroIDE-0.12.155-")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"defaultModel": map[string]any{"modelId": "auto"},
+			"models": []map[string]any{
+				{"modelId": "claude-sonnet-4.6"},
+				{"modelId": "claude-opus-4.6"},
+				{"modelId": "auto"},
+			},
+		})
+	}))
+	defer server.Close()
+	setKiroUsageTestEndpoint(t, server.URL)
+
+	svc := &AccountTestService{}
+	models, err := svc.fetchKiroUpstreamModels(context.Background(), account)
+	require.NoError(t, err)
+	require.Equal(t, []string{"auto", "claude-sonnet-4.6", "claude-opus-4.6"}, models)
+}

--- a/backend/internal/service/kiro_profile_resolver.go
+++ b/backend/internal/service/kiro_profile_resolver.go
@@ -216,13 +216,46 @@ func (s *GatewayService) resolveAndPersistKiroProfileArn(ctx context.Context, ac
 // 在流式/非流式请求发送前调用，如果是 KRS 模式且 profileArn 缺失或为占位符，
 // 则触发 ListAvailableProfiles 解析并回填。
 func (s *GatewayService) ensureKiroProfileArnForRequest(ctx context.Context, account *Account, token string, mode string) {
-	if account == nil || mode != KiroEndpointModeKRS {
+	_ = mode
+	if account == nil || account.Type == AccountTypeAPIKey {
 		return
 	}
-	existingARN := strings.TrimSpace(account.GetCredential("profile_arn"))
-	if existingARN != "" && !kiroIsPlaceholderProfileARN(existingARN) {
+	if kiroAccountLacksEnterpriseProfile(account) {
+		_ = s.resolveAndPersistKiroProfileArn(ctx, account, token)
 		return
 	}
-	// 触发解析（内部有去重逻辑）
-	_ = s.resolveAndPersistKiroProfileArn(ctx, account, token)
+	ensureKiroEnterpriseRealProfileArn(ctx, s.accountRepo, account, token)
+}
+
+// ensureKiroEnterpriseRealProfileArn 为企业 IdC 解析真实 profileArn。
+// Builder ID 占位符对该身份会 403 Invalid token，失败时不回填占位符。
+func ensureKiroEnterpriseRealProfileArn(ctx context.Context, repo AccountRepository, account *Account, token string) {
+	if account == nil || strings.TrimSpace(token) == "" {
+		return
+	}
+	existing := strings.TrimSpace(resolveKiroPayloadProfileArn(account))
+	if existing != "" && !kiroIsPlaceholderProfileARN(existing) {
+		return
+	}
+	if kiroIsSocialLogin(account) || kiroAccountLacksEnterpriseProfile(account) {
+		return
+	}
+	if kiroUsageSkipEnterpriseProfileResolve {
+		return
+	}
+	profiles, err := kiroListAvailableProfiles(ctx, account, token)
+	if err != nil {
+		return
+	}
+	real := profiles.firstARN()
+	if real == "" {
+		return
+	}
+	if account.Credentials == nil {
+		account.Credentials = make(map[string]any)
+	}
+	account.Credentials["profile_arn"] = real
+	if repo != nil {
+		_ = persistAccountCredentials(ctx, repo, account, account.Credentials)
+	}
 }

--- a/backend/internal/service/kiro_runtime.go
+++ b/backend/internal/service/kiro_runtime.go
@@ -365,10 +365,7 @@ func (s *GatewayService) executeKiroUpstream(ctx context.Context, account *Accou
 func (s *GatewayService) executeKiroUpstreamWithParsed(ctx context.Context, account *Account, parsed *ParsedRequest, anthropicBody []byte, mappedModel, requestModel, token string, headers http.Header) (*http.Response, kiropkg.KiroRequestContext, error) {
 	var requestCtx kiropkg.KiroRequestContext
 	mode := kiroEndpointModeForRequest(account, parsed)
-	// KRS/Auto 模式：确保 profileArn 已解析（已有值时零开销，仅为安全兜底）
-	if mode == KiroEndpointModeAuto || mode == KiroEndpointModeKRS {
-		s.ensureKiroProfileArnForRequest(ctx, account, token, KiroEndpointModeKRS)
-	}
+	s.ensureKiroProfileArnForRequest(ctx, account, token, mode)
 	accountKey := buildKiroAccountKey(account)
 	if err := s.checkKiroCooldown(ctx, accountKey); err != nil {
 		if failoverErr := asKiroCooldownFailoverError(err); failoverErr != nil {
@@ -386,10 +383,12 @@ func (s *GatewayService) executeKiroUpstreamWithParsed(ctx context.Context, acco
 	maxRetries := 2
 
 	for idx, endpoint := range endpoints {
-		// 按端点维度构建 payload：Q 端点 profileArn 为空，KRS 端点需要 profileArn
+		// Q 与 KRS 现在都要求 profileArn。API Key 走 Q 且不能带 ARN。
 		var profileArn string
 		if endpoint.Name == "KiroRuntime" {
 			profileArn = kiroResolveProfileArnForKRS(account)
+		} else {
+			profileArn = kiroOAuthRequestProfileArn(account)
 		}
 		buildResult, err := s.buildKiroPayloadForAccountWithArn(ctx, account, parsed, anthropicBody, modelID, currentToken, requestModel, headers, profileArn)
 		if err != nil {
@@ -494,7 +493,7 @@ func (s *GatewayService) executeKiroUpstreamWithParsed(ctx context.Context, acco
 						if endpoint.Name == "KiroRuntime" {
 							profileArn = kiroResolveProfileArnForKRS(account)
 						} else {
-							profileArn = ""
+							profileArn = kiroOAuthRequestProfileArn(account)
 						}
 						buildResult, err = s.buildKiroPayloadForAccountWithArn(ctx, account, parsed, anthropicBody, modelID, currentToken, requestModel, headers, profileArn)
 						if err != nil {

--- a/backend/internal/service/kiro_runtime_state_test.go
+++ b/backend/internal/service/kiro_runtime_state_test.go
@@ -615,7 +615,7 @@ func TestExecuteKiroUpstreamAutoSwitchesFromQ429ToKRS(t *testing.T) {
 	require.NoError(t, err)
 	krsBody, err := io.ReadAll(upstream.requests[1].Body)
 	require.NoError(t, err)
-	require.NotContains(t, string(qBody), `"profileArn"`)
+	require.Contains(t, string(qBody), `"profileArn":"`+profileARN+`"`)
 	require.Contains(t, string(krsBody), `"profileArn":"`+profileARN+`"`)
 }
 

--- a/backend/internal/service/kiro_unit_helpers_test.go
+++ b/backend/internal/service/kiro_unit_helpers_test.go
@@ -10,6 +10,10 @@ import (
 	kiropkg "github.com/Wei-Shaw/sub2api/internal/pkg/kiro"
 )
 
+func init() {
+	kiroUsageSkipEnterpriseProfileResolve = true
+}
+
 func (s *GatewayService) streamKeepaliveIntervalForAccount(account *Account) time.Duration {
 	if account != nil && account.Platform == PlatformKiro {
 		if s != nil && s.cfg != nil && s.cfg.Gateway.KiroStreamKeepaliveInterval > 0 {
@@ -27,6 +31,8 @@ func (s *GatewayService) buildKiroPayloadForAccount(ctx context.Context, account
 	var profileArn string
 	if kiroEndpointModeForRequest(account, parsed) == KiroEndpointModeKRS {
 		profileArn = kiroResolveProfileArnForKRS(account)
+	} else {
+		profileArn = kiroOAuthRequestProfileArn(account)
 	}
 	return s.buildKiroPayloadForAccountWithArn(ctx, account, parsed, anthropicBody, modelID, token, requestModel, headers, profileArn)
 }

--- a/backend/internal/service/kiro_usage_fetcher.go
+++ b/backend/internal/service/kiro_usage_fetcher.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -18,13 +19,17 @@ import (
 )
 
 const (
-	kiroUsageOrigin       = "AI_EDITOR"
-	kiroUsageResourceType = "AGENTIC_REQUEST"
-
-	kiroDefaultRegion = "us-east-1"
+	kiroUsageOrigin          = "AI_EDITOR"
+	kiroUsageResourceType    = "AGENTIC_REQUEST"
+	kiroUsageIsEmailRequired = "true"
+	kiroUsagePrimaryEURegion = "eu-central-1"
+	kiroDefaultRegion        = "us-east-1"
 )
 
 var resolveKiroRuntimeEndpoint = kiroRuntimeEndpoint
+
+// 单测把 getUsageLimits 打到 httptest 时置位，避免 ensureKiroUsageProfileArn 外呼 ListAvailableProfiles。
+var kiroUsageSkipEnterpriseProfileResolve bool
 
 type kiroUsageLimitsResponse struct {
 	NextDateReset      any                  `json:"nextDateReset"`
@@ -154,16 +159,13 @@ func (s *AccountUsageService) fetchAndCacheKiroUsage(ctx context.Context, accoun
 		return nil, fmt.Errorf("no access token available")
 	}
 
-	region := kiroAPIRegion(account)
-	profileArn := resolveKiroPayloadProfileArn(account)
-
-	resp, err := s.requestKiroUsageLimits(ctx, account, region, profileArn, token)
+	resp, err := s.requestKiroUsageLimits(ctx, account, token)
 	if err != nil {
 		// API Key 账号无可刷新 token,跳过刷新重试。
 		if account.Type != AccountTypeAPIKey && s.shouldRetryKiroUsageWithRefresh(err) {
 			refreshedToken, refreshErr := s.kiroTokenProvider.ForceRefreshAccessToken(ctx, account)
 			if refreshErr == nil && strings.TrimSpace(refreshedToken) != "" {
-				resp, err = s.requestKiroUsageLimits(ctx, account, region, profileArn, strings.TrimSpace(refreshedToken))
+				resp, err = s.requestKiroUsageLimits(ctx, account, strings.TrimSpace(refreshedToken))
 				if err == nil {
 					usage := mapKiroUsageToInfo(resp)
 					usage.Source = source
@@ -250,18 +252,57 @@ func cloneUsageInfo(info *UsageInfo) *UsageInfo {
 	return &cloned
 }
 
-func (s *AccountUsageService) requestKiroUsageLimits(ctx context.Context, account *Account, region, profileArn, token string) (*kiroUsageLimitsResponse, error) {
-	endpoint := resolveKiroRuntimeEndpoint(region)
+func (s *AccountUsageService) requestKiroUsageLimits(ctx context.Context, account *Account, token string) (*kiroUsageLimitsResponse, error) {
+	var repo AccountRepository
+	if s != nil {
+		repo = s.accountRepo
+	}
+	ensureKiroEnterpriseRealProfileArn(ctx, repo, account, token)
+	profileArn := kiroUsageQueryProfileArn(account)
+	seen := make(map[string]struct{}, 2)
+	var lastErr error
+
+	candidates := kiroUsageRegionCandidates(account)
+	for i, region := range candidates {
+		endpoint := strings.TrimRight(resolveKiroRuntimeEndpoint(region), "/")
+		if endpoint == "" {
+			continue
+		}
+		if _, dup := seen[endpoint]; dup {
+			continue
+		}
+		seen[endpoint] = struct{}{}
+
+		parsed, err := s.doKiroUsageLimitsRequest(ctx, account, endpoint, token, profileArn)
+		if err == nil {
+			return parsed, nil
+		}
+		lastErr = err
+
+		var httpErr *kiroUsageHTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusForbidden && i+1 < len(candidates) {
+			continue
+		}
+		return nil, lastErr
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, fmt.Errorf("kiro usage request failed: no endpoint")
+}
+
+func (s *AccountUsageService) doKiroUsageLimitsRequest(ctx context.Context, account *Account, endpoint, token, profileArn string) (*kiroUsageLimitsResponse, error) {
 	reqURL, err := url.Parse(endpoint + "/getUsageLimits")
 	if err != nil {
 		return nil, fmt.Errorf("build kiro usage url failed: %w", err)
 	}
 	q := reqURL.Query()
 	q.Set("origin", kiroUsageOrigin)
+	q.Set("resourceType", kiroUsageResourceType)
+	q.Set("isEmailRequired", kiroUsageIsEmailRequired)
 	if profileArn = strings.TrimSpace(profileArn); profileArn != "" {
 		q.Set("profileArn", profileArn)
 	}
-	q.Set("resourceType", kiroUsageResourceType)
 	reqURL.RawQuery = q.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
@@ -309,17 +350,59 @@ func (s *AccountUsageService) applyKiroRuntimeHeaders(req *http.Request, account
 	machineID := buildKiroMachineID(account)
 	req.Header.Set("Accept", "*/*")
 	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(token))
-	req.Header.Set("User-Agent", kiropkg.BuildRuntimeUserAgent(accountKey, machineID))
-	req.Header.Set("X-Amz-User-Agent", kiropkg.BuildRuntimeAmzUserAgent(accountKey, machineID))
+	req.Header.Set("User-Agent", kiropkg.BuildUsageRuntimeUserAgent(accountKey, machineID))
+	req.Header.Set("X-Amz-User-Agent", kiropkg.BuildUsageRuntimeAmzUserAgent(accountKey, machineID))
 	req.Header.Set("x-amzn-kiro-agent-mode", "vibe")
 	req.Header.Set("x-amzn-codewhisperer-optout", "true")
-	req.Header.Set("Amz-Sdk-Request", "attempt=1; max=3")
+	req.Header.Set("Amz-Sdk-Request", "attempt=1; max=1")
 	req.Header.Set("Amz-Sdk-Invocation-Id", uuid.NewString())
 
 	if account == nil {
 		return
 	}
 	applyKiroConditionalHeaders(req, account)
+}
+
+// kiroUsageQueryProfileArn 返回用量 REST GET 必须携带的 profileArn。
+// getUsageLimits 已把 profileArn 当必填：不带会 403 "User is not authorized to make this call."
+// Builder ID 没有真实 profile，必须带 IDE 硬编码占位符；Social 用固定 social ARN；
+// Enterprise 应先由 ensureKiroUsageProfileArn 回填真实 ARN（占位符对该身份会 invalid token）。
+func kiroUsageQueryProfileArn(account *Account) string {
+	arn := strings.TrimSpace(resolveKiroPayloadProfileArn(account))
+	if arn != "" && !kiroIsPlaceholderProfileARN(arn) {
+		return arn
+	}
+	if kiroIsSocialLogin(account) {
+		return kiroSocialProfileARN
+	}
+	if kiroAccountLacksEnterpriseProfile(account) {
+		if arn != "" {
+			return arn
+		}
+		return kiroBuilderIDProfileARN
+	}
+	return ""
+}
+
+func kiroUsageRegionCandidates(account *Account) []string {
+	hint := kiroUsageHintRegion(account)
+	if hint == kiroUsagePrimaryEURegion || strings.HasPrefix(hint, "eu-") {
+		return []string{kiroUsagePrimaryEURegion, kiroDefaultRegion}
+	}
+	return []string{kiroDefaultRegion, kiroUsagePrimaryEURegion}
+}
+
+func kiroUsageHintRegion(account *Account) string {
+	if account == nil {
+		return kiroDefaultRegion
+	}
+	if api := strings.TrimSpace(account.GetCredential("api_region")); api != "" {
+		return api
+	}
+	if region := strings.TrimSpace(account.GetCredential("region")); region != "" {
+		return region
+	}
+	return kiroDefaultRegion
 }
 
 func accountProxyURL(account *Account) string {

--- a/backend/internal/service/kiro_usage_live_probe_test.go
+++ b/backend/internal/service/kiro_usage_live_probe_test.go
@@ -1,0 +1,240 @@
+//go:build live
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/httpclient"
+	kiropkg "github.com/Wei-Shaw/sub2api/internal/pkg/kiro"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
+	"github.com/stretchr/testify/require"
+)
+
+type liveExportedAccounts struct {
+	Accounts []liveExportedAccount `json:"accounts"`
+}
+
+type liveExportedAccount struct {
+	Name        string         `json:"name"`
+	Platform    string         `json:"platform"`
+	Type        string         `json:"type"`
+	Credentials map[string]any `json:"credentials"`
+}
+
+func TestLiveKiroUsageLimitsFromExportedAccount(t *testing.T) {
+	path := strings.TrimSpace(os.Getenv("KIRO_LIVE_ACCOUNT_JSON"))
+	if path == "" {
+		t.Fatal("KIRO_LIVE_ACCOUNT_JSON is required")
+	}
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var exported liveExportedAccounts
+	require.NoError(t, json.Unmarshal(raw, &exported))
+	require.NotEmpty(t, exported.Accounts)
+
+	src := exported.Accounts[0]
+	require.Equal(t, "kiro", strings.ToLower(src.Platform))
+
+	creds := src.Credentials
+	require.NotNil(t, creds)
+
+	clientID := stringCredential(creds, "client_id")
+	clientSecret := stringCredential(creds, "client_secret")
+	refreshToken := stringCredential(creds, "refresh_token")
+	region := stringCredential(creds, "region")
+	startURL := stringCredential(creds, "start_url")
+	provider := stringCredential(creds, "provider")
+	require.NotEmpty(t, clientID)
+	require.NotEmpty(t, clientSecret)
+	require.NotEmpty(t, refreshToken)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	token, err := kiropkg.RefreshIDCToken(ctx, "", clientID, clientSecret, refreshToken, region, startURL, provider)
+	require.NoError(t, err)
+	require.NotEmpty(t, token.AccessToken)
+	t.Logf("refreshed token: provider=%s auth=%s profileArn=%q email=%v expiresAt=%s",
+		token.Provider, token.AuthMethod, token.ProfileArn, token.Email != "", token.ExpiresAt)
+
+	account := &Account{
+		ID:       9001,
+		Name:     src.Name,
+		Platform: PlatformKiro,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token":  token.AccessToken,
+			"refresh_token": firstNonEmptyLive(token.RefreshToken, refreshToken),
+			"client_id":     clientID,
+			"client_secret": clientSecret,
+			"auth_method":   "idc",
+			"provider":      firstNonEmptyLive(token.Provider, provider),
+			"region":        firstNonEmptyLive(token.Region, region),
+			"start_url":     startURL,
+		},
+	}
+	if arn := strings.TrimSpace(stringCredential(creds, "profile_arn")); arn != "" {
+		account.Credentials["profile_arn"] = arn
+	}
+	if arn := strings.TrimSpace(token.ProfileArn); arn != "" {
+		account.Credentials["profile_arn"] = arn
+	}
+
+	t.Logf("account: name=%s provider=%s start_url=%s primaryARN=%q regions=%v",
+		account.Name,
+		account.GetCredential("provider"),
+		account.GetCredential("start_url"),
+		kiroUsageQueryProfileArn(account),
+		kiroUsageRegionCandidates(account),
+	)
+
+	svc := NewAccountUsageService(nil, nil, nil, nil, nil, nil, nil, nil, NewUsageCache(), nil, nil)
+	accessToken := token.AccessToken
+
+	type probe struct {
+		name       string
+		region     string
+		profileArn string
+	}
+	runProbes := func(label string, probes []probe) {
+		t.Helper()
+		for _, p := range probes {
+			endpoint := kiroRuntimeEndpoint(p.region)
+			resp, probeErr := svc.doKiroUsageLimitsRequest(ctx, account, endpoint, accessToken, p.profileArn)
+			if probeErr != nil {
+				t.Logf("%s PROBE %-22s FAIL %v", label, p.name, probeErr)
+				continue
+			}
+			t.Logf("%s PROBE %-22s OK %s", label, p.name, summarizeKiroUsage(resp))
+		}
+	}
+
+	runProbes("as-exported", []probe{
+		{name: "no_arn", region: "us-east-1", profileArn: ""},
+		{name: "placeholder", region: "us-east-1", profileArn: kiroBuilderIDProfileARN},
+		{name: "social_arn", region: "us-east-1", profileArn: kiroSocialProfileARN},
+		{name: "no_arn_eu", region: "eu-central-1", profileArn: ""},
+	})
+
+	hybrid, hybridErr := svc.requestKiroUsageLimits(ctx, account, accessToken)
+	if hybridErr != nil {
+		t.Logf("HYBRID(as-exported) FAIL %v", hybridErr)
+	} else {
+		t.Logf("HYBRID(as-exported) OK %s", summarizeKiroUsage(hybrid))
+	}
+
+	if profiles, listErr := kiroListAvailableProfiles(ctx, account, accessToken); listErr != nil {
+		t.Logf("ListAvailableProfiles: FAIL %v", listErr)
+	} else if real := profiles.firstARN(); real != "" {
+		t.Logf("ListAvailableProfiles: ok first=%q", real)
+		runProbes("with-real-arn", []probe{
+			{name: "real_arn", region: "us-east-1", profileArn: real},
+		})
+		account.Credentials["profile_arn"] = real
+		hybrid2, hybrid2Err := svc.requestKiroUsageLimits(ctx, account, accessToken)
+		if hybrid2Err != nil {
+			t.Logf("HYBRID(with-real-arn) FAIL %v", hybrid2Err)
+		} else {
+			t.Logf("HYBRID(with-real-arn) OK %s", summarizeKiroUsage(hybrid2))
+		}
+	} else {
+		t.Logf("ListAvailableProfiles: ok but empty")
+	}
+
+	require.NoError(t, hybridErr)
+	require.NotNil(t, hybrid)
+	require.NotEmpty(t, hybrid.UsageBreakdownList)
+
+	modelSvc := &AccountTestService{}
+	models, modelsErr := modelSvc.fetchKiroUpstreamModels(ctx, account)
+	if modelsErr != nil {
+		t.Fatalf("LIST MODELS FAIL %v", modelsErr)
+	}
+	t.Logf("LIST MODELS OK count=%d sample=%v", len(models), trimModelSample(models, 8))
+	require.NotEmpty(t, models)
+
+	testSvc := &AccountTestService{
+		httpUpstream:        liveKiroHTTPUpstream{},
+		tlsFPProfileService: &TLSFingerprintProfileService{},
+	}
+	payload, err := createTestPayload("claude-sonnet-4.6")
+	require.NoError(t, err)
+	payloadBytes, err := json.Marshal(payload)
+	require.NoError(t, err)
+	chatResp, chatErr := testSvc.executeKiroTestUpstream(ctx, account, payloadBytes, "claude-sonnet-4.6", accessToken)
+	require.NoError(t, chatErr)
+	defer func() { _ = chatResp.Body.Close() }()
+	t.Logf("CHAT TEST HTTP %d", chatResp.StatusCode)
+	require.Equal(t, http.StatusOK, chatResp.StatusCode)
+}
+
+func trimModelSample(models []string, n int) []string {
+	if len(models) <= n {
+		return models
+	}
+	return models[:n]
+}
+
+type liveKiroHTTPUpstream struct{}
+
+func (liveKiroHTTPUpstream) Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
+	return liveKiroHTTPUpstream{}.DoWithTLS(req, proxyURL, accountID, accountConcurrency, nil)
+}
+
+func (liveKiroHTTPUpstream) DoWithTLS(req *http.Request, proxyURL string, _ int64, _ int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	client, err := httpclient.GetClient(httpclient.Options{
+		ProxyURL:           proxyURL,
+		Timeout:            60 * time.Second,
+		ValidateResolvedIP: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(req)
+}
+
+func stringCredential(creds map[string]any, key string) string {
+	if creds == nil {
+		return ""
+	}
+	v, ok := creds[key]
+	if !ok || v == nil {
+		return ""
+	}
+	s, _ := v.(string)
+	return strings.TrimSpace(s)
+}
+
+func firstNonEmptyLive(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func summarizeKiroUsage(resp *kiroUsageLimitsResponse) string {
+	if resp == nil {
+		return "nil"
+	}
+	credit := selectKiroCreditBreakdown(resp.UsageBreakdownList)
+	current, limit := 0.0, 0.0
+	if credit != nil {
+		current = selectKiroFloat(credit.CurrentUsageWithPrecision, credit.CurrentUsage)
+		limit = selectKiroFloat(credit.UsageLimitWithPrecision, credit.UsageLimit)
+	}
+	return fmt.Sprintf("sub=%q type=%q credit=%.4f/%.4f reset=%v",
+		strings.TrimSpace(resp.SubscriptionInfo.SubscriptionTitle),
+		strings.TrimSpace(resp.SubscriptionInfo.Type),
+		current, limit, resp.NextDateReset)
+}

--- a/backend/internal/service/upstream_models.go
+++ b/backend/internal/service/upstream_models.go
@@ -82,6 +82,9 @@ func (s *AccountTestService) FetchUpstreamSupportedModels(ctx context.Context, a
 	if account.Platform == PlatformAntigravity && account.Type != AccountTypeAPIKey {
 		return s.fetchAntigravityOAuthUpstreamModels(ctx, account)
 	}
+	if account.Platform == PlatformKiro {
+		return s.fetchKiroUpstreamModels(ctx, account)
+	}
 
 	if s.httpUpstream == nil {
 		return nil, newUpstreamModelSyncConfigError("Upstream HTTP client is not configured", nil)

--- a/backend/internal/service/wire_merge_preservation_test.go
+++ b/backend/internal/service/wire_merge_preservation_test.go
@@ -26,7 +26,7 @@ func TestProvideAccountTestServicePreservesKiroAndAgentIdentityDependencies(t *t
 	gateway := &OpenAIGatewayService{}
 
 	svc := ProvideAccountTestService(
-		nil, nil, nil, kiro, nil, nil, nil, nil, nil, gateway, nil,
+		nil, nil, nil, kiro, nil, nil, nil, nil, nil, gateway, nil, nil,
 	)
 
 	require.Equal(t, kiro, svc.kiroTokenProvider)


### PR DESCRIPTION
## 问题

Kiro 上游对 Builder ID / IDC 改了协议口径后，用量查询、拉模型和测活对话会 403：

1. User-Agent 版本被当作准入条件，旧 UA（0.6 / 0.9 / 0.11）返回 `User is not authorized to make this call`
2. `profileArn` 从可选变为必填：不带会 `Invalid profileArn` / `profileArn is required`；企业账号用 Builder ID 占位符会 `Invalid token`

对齐 [kiro-manager-lite v1.0.17](https://github.com/lucks-cloud/kiro-manager-lite/releases/tag/v1.0.17) 的实测结论。

## 改动

- 用量 / 模型列表 / Q 端点对话与测活统一使用 `KiroIDE-0.12.155` + `aws-sdk-js/1.0.34`
- 按身份补齐 `profileArn`：
  - Social：固定 social ARN
  - Builder ID：IDE 占位符 ARN
  - Enterprise：`ListAvailableProfiles` 解析真实 ARN，失败不回填占位符
- 新增 Kiro `ListAvailableModels` 同步
- Q 端点 OAuth 请求不再故意剥掉 `profileArn`；API Key（`ksk_`）仍不带
- 用量主端点 403 时在 `us-east-1` / `eu-central-1` 之间回退

## 验证

- 相关单测已更新并通过
- 企业 IDC 实帐 live 探测（`-tags live`）：用量、拉模型、测活对话均成功